### PR TITLE
test: Planner

### DIFF
--- a/src/main/java/com/example/algoyweb/model/dto/planner/PlannerDto.java
+++ b/src/main/java/com/example/algoyweb/model/dto/planner/PlannerDto.java
@@ -27,6 +27,12 @@ public class PlannerDto {
 
     private String link;
 
+    private String questionName;
+
+    private String etcName;
+
+    private Planner.SiteName siteName;
+
     private Planner.Status status;
 
     private LocalDateTime createAt;

--- a/src/main/java/com/example/algoyweb/model/entity/planner/Planner.java
+++ b/src/main/java/com/example/algoyweb/model/entity/planner/Planner.java
@@ -38,7 +38,15 @@ public class Planner {
     private String link;
 
     @Column(nullable = false)
+    private String questionName;
+
+    @Column(nullable = false)
     private Status status;
+
+    @Column(nullable = false)
+    private SiteName siteName;
+
+    private String etcName;
 
     private LocalDateTime createAt;
 
@@ -53,6 +61,13 @@ public class Planner {
         DONE
     }
 
+    public enum SiteName {
+        BOJ,
+        PGS,
+        SWEA,
+        ETC
+    }
+
     public void updatePlan(PlannerDto plannerDto) {
         this.title = plannerDto.getTitle();
         this.content = plannerDto.getContent();
@@ -61,6 +76,9 @@ public class Planner {
         this.link = plannerDto.getLink();
         this.status = plannerDto.getStatus();
         this.updateAt = LocalDateTime.now();
+        this.questionName = plannerDto.getQuestionName();
+        this.siteName = plannerDto.getSiteName();
+        this.etcName = plannerDto.getEtcName();
     }
 
     public void connectUser(User user) {

--- a/src/main/java/com/example/algoyweb/repository/planner/PlannerRepository.java
+++ b/src/main/java/com/example/algoyweb/repository/planner/PlannerRepository.java
@@ -5,14 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
 public interface PlannerRepository extends JpaRepository<Planner, Long> {
 
     @Query("select p from Planner p where p.startAt >= :startTime and p.startAt <= :endTime")
-    List<Planner> findByMonth(LocalDateTime startTime, LocalDateTime endTime);
+    List<Planner> findByMonth(LocalDate startTime, LocalDate endTime);
 
     @Query("select p from Planner p where p.user.email = :username")
     List<Planner> findByUserEmail(String username);

--- a/src/main/java/com/example/algoyweb/service/planner/PlannerService.java
+++ b/src/main/java/com/example/algoyweb/service/planner/PlannerService.java
@@ -4,7 +4,6 @@ import com.example.algoyweb.model.entity.planner.Planner;
 import com.example.algoyweb.model.dto.planner.PlannerDto;
 import com.example.algoyweb.exception.CustomException;
 import com.example.algoyweb.exception.PlannerErrorCode;
-import com.example.algoyweb.model.entity.user.User;
 import com.example.algoyweb.repository.planner.PlannerRepository;
 import com.example.algoyweb.repository.user.UserRepository;
 import com.example.algoyweb.util.ConvertUtils;
@@ -12,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.Collections;
@@ -29,11 +29,11 @@ public class PlannerService {
 
     @Transactional(readOnly = true)
     public List<PlannerDto> getPlansMonth(int year, int month) {
-        LocalDateTime startTime = LocalDateTime.of(year, month, 1, 0, 0);
+        LocalDate startTime = LocalDate.of(year, month, 1);
 
         YearMonth yearMonth = YearMonth.from(startTime);
         int lastDayOfMonth = yearMonth.lengthOfMonth();
-        LocalDateTime endTime = LocalDateTime.of(year, month, lastDayOfMonth, 0, 0);
+        LocalDate endTime = LocalDate.of(year, month, lastDayOfMonth);
 
         return Optional.of(plannerRepository.findByMonth(startTime, endTime)).orElseGet(Collections::emptyList).stream()
                 .map(ConvertUtils::convertPlannerToDto).toList();

--- a/src/main/java/com/example/algoyweb/util/ConvertUtils.java
+++ b/src/main/java/com/example/algoyweb/util/ConvertUtils.java
@@ -9,44 +9,50 @@ import java.time.LocalDateTime;
 
 public class ConvertUtils {
 
-    public static PlannerDto convertPlannerToDto(Planner planner) {
-        return PlannerDto.builder()
-                .id(planner.getId())
-                .title(planner.getTitle())
-                .endAt(planner.getEndAt())
-                .startAt(planner.getStartAt())
-                .content(planner.getContent())
-                .createAt(planner.getCreateAt())
-                .status(planner.getStatus())
-                .updateAt(planner.getUpdateAt())
-                .link(planner.getLink())
-                .build();
-    }
+  public static PlannerDto convertPlannerToDto(Planner planner) {
+    return PlannerDto.builder()
+        .id(planner.getId())
+        .title(planner.getTitle())
+        .endAt(planner.getEndAt())
+        .startAt(planner.getStartAt())
+        .content(planner.getContent())
+        .createAt(planner.getCreateAt())
+        .status(planner.getStatus())
+        .updateAt(planner.getUpdateAt())
+        .link(planner.getLink())
+        .questionName(planner.getQuestionName())
+            .etcName(planner.getEtcName())
+        .siteName(planner.getSiteName())
+        .build();
+  }
 
-    public static Planner convertDtoToPlanner(PlannerDto plannerDto) {
-        return Planner.builder()
-                .content(plannerDto.getContent())
-                .createAt(LocalDateTime.now())
-                .status(plannerDto.getStatus())
-                .updateAt(LocalDateTime.now())
-                .endAt(plannerDto.getEndAt())
-                .title(plannerDto.getTitle())
-                .startAt(plannerDto.getStartAt())
-                .link(plannerDto.getLink())
-                .build();
-    }
+  public static Planner convertDtoToPlanner(PlannerDto plannerDto) {
+    return Planner.builder()
+        .content(plannerDto.getContent())
+        .createAt(LocalDateTime.now())
+        .status(plannerDto.getStatus())
+        .updateAt(LocalDateTime.now())
+        .endAt(plannerDto.getEndAt())
+        .title(plannerDto.getTitle())
+        .startAt(plannerDto.getStartAt())
+        .link(plannerDto.getLink())
+        .siteName(plannerDto.getSiteName())
+            .etcName(plannerDto.getEtcName())
+        .questionName(plannerDto.getQuestionName())
+        .build();
+  }
 
-    public static UserDto convertUserToDto(User findUser) {
-        return UserDto.builder()
-            .role(findUser.getRole())
-            .username(findUser.getUsername())
-            .email(findUser.getEmail())
-            .nickname(findUser.getNickname())
-            .userId(findUser.getUserId())
-            .isDeleted(findUser.getIsDeleted())
-            .createdAt(findUser.getCreatedAt())
-            .updatedAt(findUser.getUpdatedAt())
-            .deletedAt(findUser.getDeletedAt())
-            .build();
-    }
+  public static UserDto convertUserToDto(User findUser) {
+    return UserDto.builder()
+        .role(findUser.getRole())
+        .username(findUser.getUsername())
+        .email(findUser.getEmail())
+        .nickname(findUser.getNickname())
+        .userId(findUser.getUserId())
+        .isDeleted(findUser.getIsDeleted())
+        .createdAt(findUser.getCreatedAt())
+        .updatedAt(findUser.getUpdatedAt())
+        .deletedAt(findUser.getDeletedAt())
+        .build();
+  }
 }

--- a/src/main/resources/static/css/planner/PlannerEditForm.css
+++ b/src/main/resources/static/css/planner/PlannerEditForm.css
@@ -212,8 +212,26 @@ input[type="radio"] {
     border-radius: 4px;
     cursor: pointer;
     font-size: 16px;
+    margin-bottom: 100px;
 }
 
 .btn-update:hover {
     background-color: #0056b3;
+}
+
+#site-dropdown {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-sizing: border-box;
+    margin-top: 5px;
+}
+
+#etc-input {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-sizing: border-box;
 }

--- a/src/main/resources/static/css/planner/PlannerMainCss.css
+++ b/src/main/resources/static/css/planner/PlannerMainCss.css
@@ -148,20 +148,9 @@ body {
     cursor: pointer;
 }
 
-/*
-#btn-edit {
-    background-color: #007bff;
-    width: 84px;
-    height: 40px;
-    color: white;
-    border: none;
-    border-radius: 12px;
-    font-size: 14px;
-    font-weight: bold;
-    cursor: pointer;
-    float:right;
-    margin-bottom:50px;
-}*/
+#btn-calendar:hover {
+    background-color: #0056b3;
+}
 
 /* table styling */
 .planner-container {
@@ -264,7 +253,6 @@ th {
     display: none;
 }
 
-/* Modal styling */
 .modal {
     display: none;
     position: fixed;
@@ -273,42 +261,22 @@ th {
     top: 0;
     width: 100%;
     height: 100%;
-    overflow: auto;
+    overflow: hidden;
     background-color: rgba(0, 0, 0, 0.4);
 }
 
-/* 기존 모달 관련 스타일 */
 .modal-content {
     background-color: #fff;
-    margin: 10% auto;
-    border: 1px solid #888;
-    width: 400px;
+    border: 1px solid #ddd;
+    min-width: 800px;
+    min-height: 600px;
     border-radius: 8px;
-    position: relative;
-    /* 버튼을 위한 공간 확보 */
-    padding: 20px 20px 50px;
-}
-
-/* 새로 추가된 버튼 스타일 */
-.modal-content #btn-edit {
     position: absolute;
-    bottom: 15px;
-    right: 15px;
-    padding: 10px 20px;
-    background-color: #007bff;
-    color: #fff;
-    border: none;
-    border-radius: 12px;
-    cursor: pointer;
-    width: 84px;
-    height: 40px;
-    font-size: 14px;
-    font-weight: bold;
-    float:right;
-}
-
-.modal-content #btn-edit:hover {
-    background-color: #0056b3;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    padding: 40px 60px 20px;
+    box-sizing: border-box;
 }
 
 .modal-close {
@@ -327,22 +295,61 @@ th {
     cursor: pointer;
 }
 
-/* Styling for modal content */
 .modal-content h2 {
     margin-top: 0;
-    font-size: 18px;
-    color: #333;
+    font-size: 28px;
+    font-weight: bold;
+    color: #000;
 }
 
-.modal-content p {
+.modal-button-group {
+    position: absolute;
+    bottom: 20px;
+    right: 60px;
+    display: flex;
+    gap: 30px;
+}
+
+.modal-button-group button {
+    background-color: #007bff;
+    color: #fff;
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+    width: 84px;
+    height: 40px;
     font-size: 14px;
+    font-weight: bold;
+}
+
+.modal-button-group #btn-edit:hover,
+.modal-button-group #btn-delete:hover {
+    background-color: #0056b3;
+}
+
+#modal-content {
+    min-height: 279px;
+    overflow-y: auto;
+    font-size: 16px;
+    color: #333;
+    border: 1px solid #e3e3e3;
+    padding: 10px;
+    background-color: #f9f9f9;
+    border-radius: 4px;
+}
+
+#modal-info {
+    margin-top: 20px;
+    font-size: 12px;
     color: #666;
 }
 
-.modal-content .link {
-    margin-top: 10px;
-    font-size: 14px;
+#modal-info a {
     color: #007bff;
     text-decoration: underline;
     cursor: pointer;
+}
+
+#modal-info a:hover {
+    color: #0056b3;
 }

--- a/src/main/resources/static/css/planner/PlannerSaveForm.css
+++ b/src/main/resources/static/css/planner/PlannerSaveForm.css
@@ -213,8 +213,26 @@ input[type="radio"] {
     border-radius: 4px;
     cursor: pointer;
     font-size: 16px;
+    margin-bottom: 100px;
 }
 
 .btn-create:hover {
     background-color: #0056b3;
+}
+
+#site-dropdown {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-sizing: border-box;
+    margin-top: 5px;
+}
+
+#etc-input {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-sizing: border-box;
 }

--- a/src/main/resources/static/js/planner/EditFormJs.js
+++ b/src/main/resources/static/js/planner/EditFormJs.js
@@ -11,6 +11,12 @@ $(document).ready(function (){
             $(`input:radio[name="status"][value="${data.status}"]`).prop('checked', true);
             $('#start-date').val(data.startAt);
             $('#end-date').val(data.endAt);
+            $('#site-dropdown').val(data.siteName);
+            if(data.siteName === 'ETC') {
+                $('#etc-input').show();
+                $('#etc-input').val(data.etcName);
+            }
+            $('#question').val(data.questionName);
         },
         error: function (error) {
             alert('조회에 실패했습니다.');
@@ -26,6 +32,9 @@ $('.btn-update').on('click', function(event) {
     const link = $('#link').val().trim();
     const startAt = $('#start-date').val().trim();
     const endAt = $('#end-date').val().trim();
+    const questionName = $('#question').val().trim();
+    const siteName = $('#site-dropdown').val().trim();
+    const etcName = $('#etc-input').val().trim();
 
     if (title === "") {
         alert('제목을 입력해주세요.');
@@ -47,16 +56,45 @@ $('.btn-update').on('click', function(event) {
         alert('종료 날짜를 입력해주세요');
         return;
     }
+    if(questionName === "") {
+        alert('문제 이름을 입력해주세요');
+        return;
+    }
+    if(siteName === "ETC" && etcName === "") {
+        alert('사이트 이름을 입력해주세요');
+        return;
+    }
+
+    if(questionName.length > 20) {
+        alert('문제 이름이 너무 깁니다.');
+        $('#question').val('');
+        return;
+    }
+    if(etcName.length > 20) {
+        alert('사이트 이름이 너무 깁니다.');
+        $('#etc-input').val('');
+        return;
+    }
 
     // json 통신할 객체 생성
-    const plannerDto = {
+    let plannerDto = {
         title: $('#title').val(),
         content: $('#content').val(),
         link: $('#link').val(),
         startAt: $('#start-date').val(),
         endAt: $('#end-date').val(),
-        status: $(':radio[name="status"]:checked').val()
+        status: $(':radio[name="status"]:checked').val(),
+        questionName: $('#question').val()
     };
+    console.log(plannerDto.questionName);
+
+    if(siteName === "ETC") {
+        plannerDto.siteName = $('#site-dropdown').val();
+        plannerDto.etcName = $('#etc-input').val();
+    } else {
+        plannerDto.siteName = $('#site-dropdown').val();
+    }
+
     $.ajax({
         type: "POST",
         url: "/algoy/planner/edit/" + id,
@@ -74,3 +112,13 @@ $('.btn-update').on('click', function(event) {
         }
     })
 })
+
+$(document).ready(function() {
+    $('#site-dropdown').change(function () {
+        if ($('#site-dropdown').val() === 'ETC') {
+            $('#etc-input').show();
+        } else {
+            $('#etc-input').hide();
+        }
+    });
+});

--- a/src/main/resources/static/js/planner/PlannerMainJs.js
+++ b/src/main/resources/static/js/planner/PlannerMainJs.js
@@ -24,12 +24,25 @@ $(document).ready(function() {
                     statusText = '완료';
                 }
 
+                let convertSiteName = '';
+
+                if(item.siteName.trim() === "BOJ") {
+                    convertSiteName = 'Baekjoon';
+                } else if(item.siteName.trim() === "PGS"){
+                    convertSiteName = 'Programmers';
+                } else if(item.siteName.trim() === "SWEA") {
+                    convertSiteName = 'SW Expert Academy';
+                } else if(item.siteName.trim() === "ETC") {
+                    convertSiteName = 'ETC';
+                }
+
                 // 테이블 행 추가
                 let row = '<tr>' +
                     '<td>' + item.id + '</td>' +
                     '<td>' + item.title + '</td>' +
                     '<td><a href="#" class="table-content" data-id="' + item.id + '">Content</a></td>' +
-                    '<td><a href="' + item.url + '">Link</a></td>' +
+                    '<td>' + convertSiteName + '</td>' +
+                    '<td>' + item.questionName + '</td>' +
                     '<td class="planner-table-status-container"><div class="' + statusClass + '">' + statusText + '</div></td>' +
                     '</tr>';
 
@@ -82,6 +95,25 @@ $(document).ready(function() {
         });
     })
 
+    // 플랜 삭제로 넘어가는 버튼 입력 이벤트 핸들러
+    $('#btn-delete').on('click', function(event) {
+        event.preventDefault();
+
+        // 클릭된 버튼에서 data-id 값을 가져와 변수에 저장
+        let plannerId = $(this).data('id');
+        $.ajax({
+            url: '/algoy/planner/delete/' + plannerId,
+            method: 'POST',
+            success: function (data) {
+                alert('플랜 삭제 성공');
+                location.href = '/algoy/planner/calender';
+            },
+            error: function (error) {
+                alert('플래너 삭제 에러 : ' + error.statusText);
+            }
+        });
+    })
+
     // 모달 불러오는 ajax 메소드
     function loadPlannerDetail(plannerId) {
         $.ajax({
@@ -90,15 +122,23 @@ $(document).ready(function() {
             success: function(data) {
                 $('#modal-title').text(data.title);
                 $('#modal-content').text(data.content);
-                $('#modal-createdAt').text(data.createAt);
-                $('#modal-updatedAt').text(data.updateAt);
-                $('#modal-startAt').text(data.startAt);
-                $('#modal-endAt').text(data.endAt);
+                $('#modal-createdAt').text(`Created on ${formatDateTime(data.createAt)}`);
+                $('#modal-timeAt').text(`${formatDate(data.startAt)} ~ ${formatDate(data.endAt)}`);
+                $('#modal-question').text(data.questionName);
+                if(data.siteName.trim() === "BOJ") {
+                    $('#modal-site').text("Baekjoon");
+                } else if(data.siteName.trim() === "PGS"){
+                    $('#modal-site').text("Programmers");
+                } else if(data.siteName.trim() === "SWEA") {
+                    $('#modal-site').text("SW Expert Academy");
+                } else if(data.siteName.trim() === "ETC") {
+                    $('#modal-site').text(data.etcName);
+                }
                 $('#modal-link').attr('href', data.link);
                 $('#modal-link').text(data.link);
                 $('#planner-modal').show();
                 $('#btn-edit').attr('data-id', data.id);
-                console.log(data.id);
+                $('#btn-delete').attr('data-id', data.id);
             },
             error: function(error) {
                 alert('플래너 로딩 에러 : ' + error.statusText);
@@ -117,4 +157,17 @@ $(document).ready(function() {
             $('#planner-modal').hide();
         }
     });
+
+    // 시간을 포맷팅하는 함수
+    function formatDateTime(dateTimeString) {
+        const options = { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' };
+        const date = new Date(dateTimeString);
+        return date.toLocaleDateString('en-US', options);
+    }
+
+    function formatDate(dateTimeString) {
+        const options = { year: 'numeric', month: 'short', day: 'numeric'};
+        const date = new Date(dateTimeString);
+        return date.toLocaleDateString('en-US', options);
+    }
 });

--- a/src/main/resources/static/js/planner/SaveFormJs.js
+++ b/src/main/resources/static/js/planner/SaveFormJs.js
@@ -9,6 +9,9 @@ $('.btn-create').on('click', function (event) {
     const link = $('#link').val().trim();
     const startAt = $('#start-date').val().trim();
     const endAt = $('#end-date').val().trim();
+    const questionName = $('#question').val().trim();
+    const siteName = $('#site-dropdown').val().trim();
+    const etcName = $('#etc-input').val().trim();
 
     if (title === "") {
         alert('제목을 입력해주세요.');
@@ -30,16 +33,43 @@ $('.btn-create').on('click', function (event) {
         alert('종료 날짜를 입력해주세요');
         return;
     }
+    if(questionName === "") {
+        alert('문제 이름을 입력해주세요');
+        return;
+    }
+    if(siteName === "ETC" && etcName === "") {
+        alert('사이트 이름을 입력해주세요');
+        return;
+    }
+
+    if(questionName.length > 20) {
+        alert('문제 이름이 너무 깁니다.');
+        $('#question').val('');
+        return;
+    }
+    if(etcName.length > 20) {
+        alert('사이트 이름이 너무 깁니다.');
+        $('#etc-input').val('');
+        return;
+    }
 
     // json 통신할 객체 생성
-    const plannerDto = {
+    let plannerDto = {
         title: $('#title').val(),
         content: $('#content').val(),
         link: $('#link').val(),
         startAt: $('#start-date').val(),
         endAt: $('#end-date').val(),
-        status: $(':radio[name="status"]:checked').val()
+        status: $(':radio[name="status"]:checked').val(),
+        questionName: $('#question').val()
     };
+
+    if(siteName === "ETC") {
+        plannerDto.siteName = $('#site-dropdown').val();
+        plannerDto.etcName = $('#etc-input').val();
+    } else {
+        plannerDto.siteName = $('#site-dropdown').val();
+    }
 
     // json 통신
     $.ajax({
@@ -53,6 +83,16 @@ $('.btn-create').on('click', function (event) {
         },
         error: function (error) {
             alert('등록에 실패했습니다.');
+        }
+    });
+});
+
+$(document).ready(function() {
+    $('#site-dropdown').change(function () {
+        if ($('#site-dropdown').val() === 'ETC') {
+            $('#etc-input').show();
+        } else {
+            $('#etc-input').hide();
         }
     });
 });

--- a/src/main/resources/templates/planner/EditForm.html
+++ b/src/main/resources/templates/planner/EditForm.html
@@ -39,7 +39,7 @@
     </div>
 </div>
 <div class="save-container">
-    <h1>새 플랜</h1>
+    <h1>플랜 수정</h1>
     <form>
         <div class="form-group">
             <label for="title">Title</label>
@@ -60,6 +60,21 @@
                 <label><input type="radio" name="status" value="IN_PROGRESS"> 진행 중</label>
                 <label><input type="radio" name="status" value="DONE"> 완료</label>
             </div>
+        </div>
+        <div class="form-group">
+            <label for="question">Question</label>
+            <input type="text" id="question" placeholder="문제 이름을 입력해주세요">
+        </div>
+        <div class="form-group">
+            <label for="site-dropdown">Site</label>
+            <select id="site-dropdown">
+                <option value="BOJ">백준</option>
+                <option value="PGS">프로그래머스</option>
+                <option value="SWEA">SW Expert Academy</option>
+                <option value="ETC">ETC</option>
+            </select>
+            <label for="etc-input"></label>
+            <input type="text" id="etc-input" placeholder="기타 사이트 이름을 입력해 주세요" style="display:none; margin-top:10px;">
         </div>
         <div class="form-group">
             <label for="start-date">Start date</label>

--- a/src/main/resources/templates/planner/PlannerMain.html
+++ b/src/main/resources/templates/planner/PlannerMain.html
@@ -56,7 +56,8 @@
                 <th style="width: 50px">No.</th>
                 <th>Title</th>
                 <th>Content</th>
-                <th>Link</th>
+                <th>Site</th>
+                <th>Question</th>
                 <th style="width: 120px">Status</th>
             </tr>
             </thead>
@@ -65,17 +66,32 @@
         </table>
     </div>
 </div>
+<!-- 모달 구조 -->
 <div id="planner-modal" class="modal">
     <div class="modal-content">
         <span class="modal-close">&times;</span>
-        <h2 id="modal-title">제목</h2>
-        <p><strong>내용:</strong> <span id="modal-content">Loading...</span></p>
-        <p><strong>만들어진 시간:</strong> <span id="modal-createdAt">Loading...</span></p>
-        <p><strong>업데이트된 시간:</strong> <span id="modal-updatedAt">Loading...</span></p>
-        <p><strong>시작 날짜:</strong> <span id="modal-startAt">Loading...</span></p>
-        <p><strong>끝난 날짜:</strong> <span id="modal-endAt">Loading...</span></p>
-        <p><strong>문제 링크:</strong> <a href="#" id="modal-link" target="_blank">Loading...</a></p>
-        <button id="btn-edit">Edit</button>
+        <!-- 제목 -->
+        <h2 id="modal-title">Title</h2>
+        <!-- 본문이 들어갈 div 요소 -->
+        <div id="modal-content" style="border: 1px solid #e3e3e3; padding: 15px; min-height: 279px; margin-top: 20px;">
+            <p>Loading...</p>
+        </div>
+        <!-- 작성된 시간 -->
+        <div id="modal-info" style="font-size: 12px; color: #666; margin-top: 30px;">
+            <p><span id="modal-createdAt">Loading...</span></p>
+            <!-- 문제 링크와 관련된 이슈 -->
+            <p>Related issues - <a href="#" id="modal-link" target="_blank">Loading...</a></p>
+            <!-- 플랜 작업 시간 -->
+            <p><span id="modal-timeAt"></span></p>
+            <!-- 문제 이름 -->
+            <p>Question Name - <span id="modal-question">Loading...</span></p>
+            <!-- 사이트 이름 -->
+            <p>Site Name - <span id="modal-site">Loading...</span></p>
+        </div>
+        <div class="modal-button-group">
+            <button id="btn-edit">수정</button>
+            <button id="btn-delete">삭제</button>
+        </div>
     </div>
 </div>
 </body>

--- a/src/main/resources/templates/planner/SaveForm.html
+++ b/src/main/resources/templates/planner/SaveForm.html
@@ -62,6 +62,21 @@
             </div>
         </div>
         <div class="form-group">
+            <label for="question">Question</label>
+            <input type="text" id="question" placeholder="문제 이름을 입력해주세요">
+        </div>
+        <div class="form-group">
+            <label for="site-dropdown">Site</label>
+            <select id="site-dropdown">
+                <option value="BOJ">백준</option>
+                <option value="PGS">프로그래머스</option>
+                <option value="SWEA">SW Expert Academy</option>
+                <option value="ETC">ETC</option>
+            </select>
+            <label for="etc-input"></label>
+            <input type="text" id="etc-input" placeholder="기타 사이트 이름을 입력해 주세요" style="display:none; margin-top:10px;">
+        </div>
+        <div class="form-group">
             <label for="start-date">Start date</label>
             <input type="date" id="start-date">
         </div>

--- a/src/test/java/com/example/service/planner/PlannerServiceTest.java
+++ b/src/test/java/com/example/service/planner/PlannerServiceTest.java
@@ -1,0 +1,348 @@
+package com.example.service.planner;
+
+import com.example.algoyweb.exception.CustomException;
+import com.example.algoyweb.exception.PlannerErrorCode;
+import com.example.algoyweb.model.dto.planner.PlannerDto;
+import com.example.algoyweb.model.entity.planner.Planner;
+import com.example.algoyweb.model.entity.user.Role;
+import com.example.algoyweb.model.entity.user.User;
+import com.example.algoyweb.repository.planner.PlannerRepository;
+import com.example.algoyweb.repository.user.UserRepository;
+import com.example.algoyweb.service.planner.PlannerService;
+import com.example.algoyweb.util.ConvertUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PlannerServiceTest {
+
+    @Mock
+    private PlannerRepository plannerRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private PlannerService plannerService;
+
+    @Test
+    public void testSavePlanner() {
+        // Given
+        PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        User user = User.builder()
+                .email("user@naver.com")
+                .password(passwordEncoder.encode("password"))
+                .nickname("user")
+                .role(Role.NORMAL)
+                .username("user")
+                .build();
+
+        Planner planner = Planner.builder()
+                .link("Link")
+                .endAt(LocalDate.now())
+                .status(Planner.Status.DONE)
+                .startAt(LocalDate.now())
+                .title("My Planner")
+                .content("Description")
+                .createAt(LocalDateTime.now())
+                .updateAt(LocalDateTime.now())
+                .build();
+
+        // Mocking
+        when(userRepository.findByEmail("user@naver.com")).thenReturn(user);
+        when(plannerRepository.save(any(Planner.class))).thenReturn(planner);
+
+        // When
+        PlannerDto savedPlanner = plannerService.savePlan(ConvertUtils.convertPlannerToDto(planner), "user@naver.com");
+
+
+        // Then
+        assertEquals("My Planner", savedPlanner.getTitle());
+        assertEquals("Description", savedPlanner.getContent());
+        assertEquals("Link", savedPlanner.getLink());
+
+        verify(plannerRepository, times(1)).save(any(Planner.class));
+    }
+
+    @Test
+    public void testDeletePlanner() {
+        // Given
+        PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        User user = User.builder()
+                .email("user@naver.com")
+                .password(passwordEncoder.encode("password"))
+                .nickname("user")
+                .role(Role.NORMAL)
+                .username("user")
+                .build();
+
+        Planner planner = Planner.builder()
+                .id(1L)
+                .link("Link")
+                .endAt(LocalDate.now())
+                .status(Planner.Status.DONE)
+                .startAt(LocalDate.now())
+                .title("My Planner")
+                .content("Description")
+                .createAt(LocalDateTime.now())
+                .updateAt(LocalDateTime.now())
+                .user(user)
+                .build();
+
+        // Mocking
+        when(plannerRepository.findById(1L)).thenReturn(Optional.ofNullable(planner));
+
+        // When
+        plannerService.deletePlan(planner.getId(), "user@naver.com");
+
+        // Then
+        verify(plannerRepository, times(1)).delete(planner);
+    }
+
+    @Test
+    public void testUpdatePlanner() {
+        // Given
+        PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        User user = User.builder()
+                .email("user@naver.com")
+                .password(passwordEncoder.encode("password"))
+                .nickname("user")
+                .role(Role.NORMAL)
+                .username("user")
+                .build();
+
+        Planner planner = Planner.builder()
+                .id(1L)
+                .link("Link")
+                .endAt(LocalDate.now())
+                .status(Planner.Status.DONE)
+                .startAt(LocalDate.now())
+                .title("My Planner")
+                .content("Description")
+                .createAt(LocalDateTime.now())
+                .updateAt(LocalDateTime.now())
+                .user(user)
+                .build();
+
+        // Mocking
+        when(plannerRepository.findById(1L)).thenReturn(Optional.ofNullable(planner));
+
+        // When
+        Planner updatedPlanner = ConvertUtils.convertDtoToPlanner(plannerService.updatePlan(PlannerDto.builder()
+            .link("Updated Link")
+            .endAt(LocalDate.now())
+            .status(Planner.Status.DONE)
+            .startAt(LocalDate.now())
+            .title("Updated Planner")
+            .content("Updated Description")
+            .createAt(LocalDateTime.now())
+            .updateAt(LocalDateTime.now())
+            .build(),
+            planner.getId(), "user@naver.com"));
+
+        // Then
+        assertEquals("Updated Planner", updatedPlanner.getTitle());
+        assertEquals("Updated Description", updatedPlanner.getContent());
+        assertEquals("Updated Link", updatedPlanner.getLink());
+    }
+
+    @Test
+    public void testGetAllPlansByUser() {
+        // Given
+        PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        User user = User.builder()
+                .email("user@naver.com")
+                .password(passwordEncoder.encode("password"))
+                .nickname("user")
+                .role(Role.NORMAL)
+                .username("user")
+                .build();
+
+        // Create multiple planners
+        Planner planner1 = Planner.builder()
+                .id(1L)
+                .link("Link1")
+                .endAt(LocalDate.now().plusDays(1))
+                .status(Planner.Status.IN_PROGRESS)
+                .startAt(LocalDate.now())
+                .title("Planner 1")
+                .content("Description 1")
+                .createAt(LocalDateTime.now())
+                .updateAt(LocalDateTime.now())
+                .user(user)
+                .build();
+
+        Planner planner2 = Planner.builder()
+                .id(2L)
+                .link("Link2")
+                .endAt(LocalDate.now().plusDays(2))
+                .status(Planner.Status.IN_PROGRESS)
+                .startAt(LocalDate.now())
+                .title("Planner 2")
+                .content("Description 2")
+                .createAt(LocalDateTime.now())
+                .updateAt(LocalDateTime.now())
+                .user(user)
+                .build();
+
+        List<Planner> planners = Arrays.asList(planner1, planner2);
+
+        // Mocking the necessary methods
+        when(plannerRepository.findByUserEmail(user.getEmail())).thenReturn(planners);
+
+        // When
+        List<PlannerDto> getPlanners = plannerService.getPlans("user@naver.com");
+
+        // Then
+        assertEquals(2, getPlanners.size());
+        assertEquals("Planner 1", getPlanners.get(0).getTitle());
+        assertEquals("Planner 2", getPlanners.get(1).getTitle());
+        assertEquals("Description 1", getPlanners.get(0).getContent());
+        assertEquals("Description 2", getPlanners.get(1).getContent());
+
+        verify(plannerRepository, times(1)).findByUserEmail(user.getEmail());
+    }
+
+    @Test
+    public void testGetPlanSuccess() {
+        // Given
+        User user = User.builder()
+                .email("user@naver.com")
+                .nickname("user")
+                .role(Role.NORMAL)
+                .username("user")
+                .build();
+
+        Planner planner = Planner.builder()
+                .id(1L)
+                .link("Link")
+                .endAt(LocalDate.now().plusDays(1))
+                .status(Planner.Status.IN_PROGRESS)
+                .startAt(LocalDate.now())
+                .title("My Planner")
+                .content("Description")
+                .createAt(LocalDateTime.now())
+                .updateAt(LocalDateTime.now())
+                .user(user)
+                .build();
+
+        // Mocking
+        when(plannerRepository.findById(1L)).thenReturn(Optional.of(planner));
+
+        // When
+        PlannerDto getPlanner = plannerService.getPlan(1L);
+
+        // Then
+        assertEquals("My Planner", getPlanner.getTitle());
+        assertEquals("Description", getPlanner.getContent());
+        assertEquals("Link", getPlanner.getLink());
+
+        verify(plannerRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    public void testGetPlanNotFound() {
+        // Given
+        Long plannerId = 1L;
+
+        // Mocking
+        when(plannerRepository.findById(plannerId)).thenReturn(Optional.empty());
+
+        // When
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            plannerService.getPlan(plannerId);
+        });
+
+        // Then
+        assertEquals(PlannerErrorCode.PLAN_NOT_FOUND, exception.getErrorCode());
+
+        verify(plannerRepository, times(1)).findById(plannerId);
+    }
+
+    @Test
+    void testGetPlansMonthWithResults() {
+        int year = 2024;
+        int month = 9;
+
+        LocalDate startTime = LocalDate.of(year, month, 1);
+        LocalDate endTime = LocalDate.of(year, month, 30);  // September has 30 days
+
+        // Given: 가짜 Planner 엔티티 리스트
+        User user = User.builder()
+                .email("user@naver.com")
+                .nickname("user")
+                .role(Role.NORMAL)
+                .username("user")
+                .build();
+
+        Planner planner1 = Planner.builder()
+                .id(1L)
+                .link("Link")
+                .endAt(endTime)
+                .status(Planner.Status.IN_PROGRESS)
+                .startAt(startTime.plusDays(1))
+                .title("My Planner 1")
+                .content("Description")
+                .createAt(LocalDateTime.now())
+                .updateAt(LocalDateTime.now())
+                .user(user)
+                .build();
+
+        Planner planner2 = Planner.builder()
+                .id(1L)
+                .link("Link")
+                .endAt(endTime)
+                .status(Planner.Status.IN_PROGRESS)
+                .startAt(startTime.plusDays(5))
+                .title("My Planner 2")
+                .content("Description")
+                .createAt(LocalDateTime.now())
+                .updateAt(LocalDateTime.now())
+                .user(user)
+                .build();
+        List<Planner> planners = Arrays.asList(planner1, planner2);
+
+        // When: 레포지토리 메소드를 모킹
+        when(plannerRepository.findByMonth(startTime, endTime)).thenReturn(planners);
+
+        // Then: 메소드를 호출하고 결과를 검증
+        List<PlannerDto> result = plannerService.getPlansMonth(year, month);
+
+        assertEquals(2, result.size());
+        assertEquals("My Planner 1", result.get(0).getTitle());
+        assertEquals("My Planner 2", result.get(1).getTitle());
+    }
+
+    @Test
+    void testGetPlansMonthNoResults() {
+        int year = 2024;
+        int month = 9;
+
+        LocalDate startTime = LocalDate.of(year, month, 1);
+        LocalDate endTime = LocalDate.of(year, month, 30);
+
+        // When: 레포지토리 메소드를 모킹
+        when(plannerRepository.findByMonth(startTime, endTime)).thenReturn(Collections.emptyList());
+
+        // Then: 메소드를 호출하고 결과를 검증
+        List<PlannerDto> result = plannerService.getPlansMonth(year, month);
+
+        assertEquals(0, result.size());
+    }
+}


### PR DESCRIPTION
Planner 관련 테스트 생성, Planner에 테스트 이름과 사이트 이름 칼럼 생성

Closes: #72

## 요약
- test와 기존 작업물 리팩토링

## 관련 이슈
- #72 

## 변경 사항
- Planner에 questionName, siteName, etcName 칼럼을 만들고, 엔티티 생성, 업데이트를 수정, 그리고 프론트에서 출력 되도록 수정
- 테스트는 PlannerService의 모든 메소드 테스트

## 기타
- 기타 사항
