### PR TITLE
Feat: solvedAC API로 유저가 푼 100문제 가져오기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/src/main/java/com/example/algoyweb/controller/allen/AllenController.java
+++ b/src/main/java/com/example/algoyweb/controller/allen/AllenController.java
@@ -8,6 +8,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/algoy/allen")
 public class AllenController {
@@ -20,11 +22,12 @@ public class AllenController {
     }
 
     @GetMapping("/solvedac")
-    public ResponseEntity<String> solvedac(@RequestParam String userName,@AuthenticationPrincipal UserDetails userDetails) throws Exception {
+    public ResponseEntity<String> solvedac(@RequestParam String username, @AuthenticationPrincipal UserDetails userDetails) throws Exception {
         System.out.println("controller check");
         try{
-            String response = allenService.sovledacCall(userName);
-            System.out.println(response);
+            List<String> titlesList = allenService.sovledacCall(username);
+
+            System.out.println(titlesList);
             return ResponseEntity.ok("solvedac");
         }catch (Exception e){
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("api 호출 중 에러가 발생하였습니다");

--- a/src/main/java/com/example/algoyweb/model/dto/allen/SolvedACResponse.java
+++ b/src/main/java/com/example/algoyweb/model/dto/allen/SolvedACResponse.java
@@ -1,0 +1,62 @@
+package com.example.algoyweb.model.dto.allen;
+
+import com.google.gson.annotations.SerializedName;
+import java.util.List;
+
+//데이터베이스와 상관없는 Json 파싱을 위한 클래스 구현입니다
+//JSON 구조를 반영한 Java 클래스 생성
+//items -> titles -> title 최종 추출하여 리스트 생성
+public class SolvedACResponse {
+    //문제수(전체 원소 수)
+    @SerializedName("count")
+    private int count;
+    //문제 내용(현재 페이지의 원소 목록)
+    @SerializedName("items")
+    private List<Item> items;
+
+    public int getCount() {
+        return count;
+    }
+
+    public List<Item> getItems() {
+        return items;
+    }
+
+    // Item 문제 내용안에 또다른 Json
+    public static class Item {
+        //문제 아이디(백준 문제 번호로, 문제마다 고유)
+        @SerializedName("problemId")
+        private int problemId;
+        //한국어 문제 제목입니다. HTML 엔티티나 LaTeX 수식을 포함할 수 있습니다.
+        @SerializedName("titleKo")
+        private String titleKo;
+        //언어별 문제 제목 목록입니다.
+        @SerializedName("titles")
+        private List<Title> titles;
+
+        public String getTitleKo() {
+            return titleKo;
+        }
+
+        public List<Title> getTitles() {
+            return titles;
+        }
+    }
+    //Titles 안에 또다른 Json
+    public static class Title {
+        //문제 제목이 작성된 언어입니다.
+        @SerializedName("language")
+        private String language;
+        //문제 제목입니다. (***추출해야할 부분***)
+        @SerializedName("title")
+        private String title;
+
+        public String getTitle() {
+            return title;
+        }
+
+        public String getLanguage() {
+            return language;
+        }
+    }
+}

--- a/src/main/java/com/example/algoyweb/service/allen/AllenService.java
+++ b/src/main/java/com/example/algoyweb/service/allen/AllenService.java
@@ -1,9 +1,13 @@
 package com.example.algoyweb.service.allen;
 
+import com.example.algoyweb.model.dto.allen.SolvedACResponse;
+import com.google.gson.Gson;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,7 +25,7 @@ public class AllenService {
     String solvedAcApi;
 
     //userName을 이용하여 sovledAC API를 통해 푼 문제 정보를 호출한다.
-    public String sovledacCall(String userName) throws Exception {
+    public List<String> sovledacCall(String userName) throws Exception {
 
         String requestUrl = solvedAcApi + userName;
 
@@ -33,16 +37,39 @@ public class AllenService {
             String result = httpEx.get(requestUrl, headers);
             System.out.println(result);
 
-            //Json을 파싱한다
+            //Json을 파싱해서 문제 제목을 list에 넣고 반환하는 메서드 호출
+            List<String> titlesList = parseSolvedACTitles(result);
+            System.out.println(titlesList);
 
-            //문제 정보를 list에 넣는다
-            return result;
+            return titlesList;
+
         } catch (Exception e){
             throw new Exception("solvedAC 호출 실패", e); //예외 발생시 상위로 전달
         }
     }
 
     //호출한 정보를 리스트에 넣는다
+    public List<String> parseSolvedACTitles(String jsonResponse){
+        //Gson 객체 생성
+        Gson gson = new Gson();
+
+        //Json을 SolvedACResponse 객체로 파싱
+        SolvedACResponse response = gson.fromJson(jsonResponse, SolvedACResponse.class);
+
+        //결과를 담을 리스트 생성
+        List<String> titlesList = new ArrayList<>();
+
+        //items 배열의 각 요소에서 titles의 title 값을 추출
+        for (SolvedACResponse.Item item : response.getItems()){
+            //titles 배열의 각 titles을 추가
+            for(SolvedACResponse.Title title : item.getTitles()){
+                if (title.getTitle() != null){
+                    titlesList.add(title.getTitle());
+                }
+            }
+        }
+        return titlesList;
+    }
 
     //질문을 allen API에 던진다.
 }


### PR DESCRIPTION
## 요약
- Json 파싱을 위한 클래스(dto) 추가
- 문제 제목을 담은 List 반환 

## 관련 이슈
- closed to #99 

## 변경 사항
- Json 형태로 받아온 문제 정보들을 파싱하여 제목만 List에 저장하였다. 

## 기타
- 추후 개발: 앨런에게 user 정보와 해당 리스트를 전송하는 기능을 구현
