### PR TITLE
Bug: 챗봇의 환경 변수 url 전달이 안되는 문제 해결

### DIFF
--- a/src/main/resources/templates/fragments/chatbot.html
+++ b/src/main/resources/templates/fragments/chatbot.html
@@ -6,8 +6,8 @@
 </head>
 <body>
 <!-- 챗봇 컴포넌트 프래그먼트 -->
-<div th:fragment="chatbot">
-  <div id="chatbot-component">
+<div th:fragment="chatbot(backendUrl)">
+  <div id="chatbot-component" th:data-backend-url="${backendUrl}">
     <div id="hamburger-menu">
       <span></span>
       <span></span>
@@ -38,12 +38,16 @@
 
   <!-- 챗봇 스크립트 -->
   <script th:src="@{/js/fragments/chatbot.js}"></script>
-  <script>
-    // 챗봇 컴포넌트 초기화
+  <script th:inline="javascript">
     document.addEventListener('DOMContentLoaded', function() {
       var chatbotElement = document.getElementById('chatbot-component');
       var backendUrl = chatbotElement.dataset.backendUrl;
-      const chatbot = new ChatbotComponent(backendUrl);
+      console.log("Backend URL from data attribute:", backendUrl);
+      if (backendUrl) {
+        const chatbot = new ChatbotComponent(backendUrl);
+      } else {
+        console.error("Backend URL is not set properly");
+      }
     });
   </script>
 </div>

--- a/src/main/resources/templates/temp/chatbot-demo.html
+++ b/src/main/resources/templates/temp/chatbot-demo.html
@@ -43,7 +43,7 @@
 </main>
 
 <!-- 챗봇 컴포넌트 포함 -->
-<div th:replace="~{fragments/chatbot :: chatbot}" th:data-backend-url="${backendUrl}"></div>
+<div th:replace="~{fragments/chatbot :: chatbot(backendUrl=${backendUrl})}"></div>Z
 
 <footer>
   <p>&copy; 2024 Our Company. All rights reserved.</p>


### PR DESCRIPTION
## 요약
- 챗봇의 환경 변수 url 전달이 안되는 문제 해결

## 관련 이슈
- Closed #119

## 변경 사항
- templates: fragments/chatbot.html과 temp/chatbot-demo.html url 전달 부분 변경

## 기타
- 다음과 같은 과정으로 해결하였습니다.
 1. application-local.yml 요청 보낼 실제 'IP:Port' 로 변경
 2. ChatBotViewController.java의 엔드포인트 매핑 부분 backendUrl 콘솔 창에 찍기 -> 문제 X
 3. html 문서에 backendUrl을 전해주는 부분에 로그 찍기 -> undefined 뜸. -> html 코드에 문제가 있음을 알 수 있음
 4. html에서 URL 전달하는 구조를 변경하여 해결