### PR TITLE
Design: 오답 노트 화면에 챗봇 프래그먼트 붙이기

### DIFF
--- a/src/main/java/com/example/algoyweb/controller/WrongAnswerNote/WrongAnswerNoteThymeleafController.java
+++ b/src/main/java/com/example/algoyweb/controller/WrongAnswerNote/WrongAnswerNoteThymeleafController.java
@@ -46,6 +46,7 @@ public class WrongAnswerNoteThymeleafController {
     @GetMapping("/create")
     public String createWrongAnswerNoteForm(Model model) {
         model.addAttribute("note", new WrongAnswerNoteDTO());
+        model.addAttribute("backendUrl", backendUrl);
         return "wronganswernote/create-wrong-answer-note";
     }
 

--- a/src/main/java/com/example/algoyweb/controller/WrongAnswerNote/WrongAnswerNoteThymeleafController.java
+++ b/src/main/java/com/example/algoyweb/controller/WrongAnswerNote/WrongAnswerNoteThymeleafController.java
@@ -36,6 +36,7 @@ public class WrongAnswerNoteThymeleafController {
         Optional<WrongAnswerNoteDTO> note = service.findById(id);
         if (note.isPresent()) {
             model.addAttribute("note", note.get());
+            model.addAttribute("backendUrl", backendUrl);
             return "wronganswernote/view-wrong-answer-note";
         } else {
             return "error";

--- a/src/main/java/com/example/algoyweb/controller/WrongAnswerNote/WrongAnswerNoteThymeleafController.java
+++ b/src/main/java/com/example/algoyweb/controller/WrongAnswerNote/WrongAnswerNoteThymeleafController.java
@@ -66,6 +66,7 @@ public class WrongAnswerNoteThymeleafController {
         Optional<WrongAnswerNoteDTO> note = service.findById(id);
         if (note.isPresent()) {
             model.addAttribute("note", note.get());
+            model.addAttribute("backendUrl", backendUrl);
             return "wronganswernote/edit-wrong-answer-note";
         } else {
             return "error";

--- a/src/main/java/com/example/algoyweb/controller/WrongAnswerNote/WrongAnswerNoteThymeleafController.java
+++ b/src/main/java/com/example/algoyweb/controller/WrongAnswerNote/WrongAnswerNoteThymeleafController.java
@@ -4,6 +4,7 @@ import com.example.algoyweb.model.dto.WrongAnswerNote.WrongAnswerNoteDTO;
 import com.example.algoyweb.service.WrongAnswerNote.WrongAnswerNoteService;
 import com.example.algoyweb.service.WrongAnswerNote.ImageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -19,9 +20,14 @@ public class WrongAnswerNoteThymeleafController {
     private final WrongAnswerNoteService service;
     private final ImageService imageService;
 
+    // ai-backend.url 설정값을 저장하는 변수입니다.
+    @Value("${ai-backend.url}")
+    private String backendUrl;
+
     @GetMapping
     public String getAllWrongAnswerNotes(Model model) {
         model.addAttribute("notes", service.findAll());
+        model.addAttribute("backendUrl", backendUrl);
         return "wronganswernote/list-wrong-answer-notes";
     }
 

--- a/src/main/resources/templates/wronganswernote/create-wrong-answer-note.html
+++ b/src/main/resources/templates/wronganswernote/create-wrong-answer-note.html
@@ -6,6 +6,16 @@
   <title>오답노트 작성</title>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/wronganswernote/create-wrong-answer-note.css">
+  <!-- jQuery 라이브러리의 압축된 버전을 CDN을 통해 불러와 현재 HTML 문서에서 사용할 수 있습니다. -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+  <!-- 웹 페이지에서 마크다운으로 작성된 내용을 HTML로 변환하여 보여주는 역할을 합니다. -->
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <!-- 웹 애플리케이션의 보안을 강화하고, 사용자 생성 콘텐츠를 안전하게 처리하는 역할을 합니다. (XSS 방지용) -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.3/purify.min.js"></script>
+  <!-- 웹 페이지 내의 코드를 시각적으로 매력적으로 표현하여 사용자 경험을 향상시키는 역할을 합니다. -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js"></script>
+  <!-- highlight.js 라이브러리와 함께 사용되어 웹 페이지 내의 코드 블록에 시각적인 스타일을 적용하는 역할을 합니다. -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/default.min.css">
 </head>
 <body>
 <header>
@@ -82,6 +92,9 @@
     </form>
 
     <div id="image-previews" style="margin-top: 20px;"></div>
+
+    <!-- 챗봇 컴포넌트 포함 -->
+    <div th:replace="~{fragments/chatbot :: chatbot(backendUrl=${backendUrl})}"></div>
   </main>
 </div>
 

--- a/src/main/resources/templates/wronganswernote/edit-wrong-answer-note.html
+++ b/src/main/resources/templates/wronganswernote/edit-wrong-answer-note.html
@@ -6,6 +6,17 @@
   <title>오답노트 수정</title>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/wronganswernote/edit-wrong-answer-note.css">
+  <!-- jQuery 라이브러리의 압축된 버전을 CDN을 통해 불러와 현재 HTML 문서에서 사용할 수 있습니다. -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+  <!-- 웹 페이지에서 마크다운으로 작성된 내용을 HTML로 변환하여 보여주는 역할을 합니다. -->
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <!-- 웹 애플리케이션의 보안을 강화하고, 사용자 생성 콘텐츠를 안전하게 처리하는 역할을 합니다. (XSS 방지용) -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.3/purify.min.js"></script>
+  <!-- 웹 페이지 내의 코드를 시각적으로 매력적으로 표현하여 사용자 경험을 향상시키는 역할을 합니다. -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js"></script>
+  <!-- highlight.js 라이브러리와 함께 사용되어 웹 페이지 내의 코드 블록에 시각적인 스타일을 적용하는 역할을 합니다. -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/default.min.css">
+  <script th:src="@{/js/fragments/modal.js}"></script>
 </head>
 <body>
 <header>
@@ -83,6 +94,9 @@
     </form>
 
     <div id="image-previews" style="margin-top: 20px;"></div>
+
+    <!-- 챗봇 컴포넌트 포함 -->
+    <div th:replace="~{fragments/chatbot :: chatbot(backendUrl=${backendUrl})}"></div>
   </main>
 </div>
 

--- a/src/main/resources/templates/wronganswernote/list-wrong-answer-notes.html
+++ b/src/main/resources/templates/wronganswernote/list-wrong-answer-notes.html
@@ -6,6 +6,17 @@
   <title>오답노트 목록</title>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/wronganswernote/list-wrong-answer-note.css">
+  <!-- jQuery 라이브러리의 압축된 버전을 CDN을 통해 불러와 현재 HTML 문서에서 사용할 수 있습니다. -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+  <!-- 웹 페이지에서 마크다운으로 작성된 내용을 HTML로 변환하여 보여주는 역할을 합니다. -->
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <!-- 웹 애플리케이션의 보안을 강화하고, 사용자 생성 콘텐츠를 안전하게 처리하는 역할을 합니다. (XSS 방지용) -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.3/purify.min.js"></script>
+  <!-- 웹 페이지 내의 코드를 시각적으로 매력적으로 표현하여 사용자 경험을 향상시키는 역할을 합니다. -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js"></script>
+  <!-- highlight.js 라이브러리와 함께 사용되어 웹 페이지 내의 코드 블록에 시각적인 스타일을 적용하는 역할을 합니다. -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/default.min.css">
+  <script th:src="@{/js/fragments/modal.js}"></script>
 </head>
 <body>
 <header>
@@ -56,6 +67,9 @@
       </div>
     </div>
   </section>
+
+  <!-- 챗봇 컴포넌트 포함 -->
+  <div th:replace="~{fragments/chatbot :: chatbot(backendUrl=${backendUrl})}"></div>
 </main>
 
 <script src="/js/wronganswernote/list.js"></script>

--- a/src/main/resources/templates/wronganswernote/view-wrong-answer-note.html
+++ b/src/main/resources/templates/wronganswernote/view-wrong-answer-note.html
@@ -6,6 +6,17 @@
   <title>오답노트 상세 페이지</title>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/wronganswernote/view-wrong-answer-note.css">
+  <!-- jQuery 라이브러리의 압축된 버전을 CDN을 통해 불러와 현재 HTML 문서에서 사용할 수 있습니다. -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+  <!-- 웹 페이지에서 마크다운으로 작성된 내용을 HTML로 변환하여 보여주는 역할을 합니다. -->
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <!-- 웹 애플리케이션의 보안을 강화하고, 사용자 생성 콘텐츠를 안전하게 처리하는 역할을 합니다. (XSS 방지용) -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.3/purify.min.js"></script>
+  <!-- 웹 페이지 내의 코드를 시각적으로 매력적으로 표현하여 사용자 경험을 향상시키는 역할을 합니다. -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js"></script>
+  <!-- highlight.js 라이브러리와 함께 사용되어 웹 페이지 내의 코드 블록에 시각적인 스타일을 적용하는 역할을 합니다. -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/default.min.css">
+  <script th:src="@{/js/fragments/modal.js}"></script>
 </head>
 <body>
 <header>
@@ -91,6 +102,9 @@
       </div>
     </div>
   </section>
+
+  <!-- 챗봇 컴포넌트 포함 -->
+  <div th:replace="~{fragments/chatbot :: chatbot(backendUrl=${backendUrl})}"></div>
 </main>
 
 <!-- 모달 입력창 -->


### PR DESCRIPTION
## 요약
- 오답 노트 화면에 챗봇 프래그먼트 붙이기

## 관련 이슈
- Related To #110 

## 변경 사항
- controller: 오답 노트 관련 html에 ai-backend.url을 전해주도록 함.
- templates: 오답 노트 관련 html의 head에 필요한 스크립트와 body에 챗봇 프래그먼트 붙임.