### PR TITLE
Refactor: 채팅 기능과 챗봇 기능 같은 페이지에서 쓸 수 있도록 조정

### DIFF
--- a/src/main/resources/static/css/fragments/chatbot.css
+++ b/src/main/resources/static/css/fragments/chatbot.css
@@ -1,13 +1,13 @@
-#chatbot-component {
+.bot-frag-component {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
-#chat-sidebar {
+.bot-frag-sidebar {
   position: fixed;
   right: -500px;
-  top: 300px; /* 헤더에 맞게 조절 */
+  top: 300px;
   width: 400px;
-  height: calc(100vh - 350px); /* 높이 조절 */
+  height: calc(100vh - 350px);
   background-color: white;
   transition: right 0.3s ease;
   box-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
@@ -15,13 +15,13 @@
   margin-right: 100px;
 }
 
-#chat-container {
+.bot-frag-container {
   height: 100%;
   display: flex;
   flex-direction: column;
 }
 
-.chat-header {
+.bot-frag-header {
   background-color: #1e88e5;
   color: white;
   padding: 15px;
@@ -29,7 +29,7 @@
   align-items: center;
 }
 
-.chat-header .avatar {
+.bot-frag-avatar {
   width: 40px;
   height: 40px;
   background-color: white;
@@ -41,18 +41,18 @@
   overflow: hidden;
 }
 
-.chat-header .avatar img {
+.bot-frag-avatar img {
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
 
-.chat-header h1 {
+.bot-frag-header h1 {
   margin: 0;
   font-size: 18px;
 }
 
-#messages {
+.bot-frag-messages {
   flex: 1;
   overflow-y: auto;
   padding: 20px;
@@ -61,7 +61,7 @@
   scroll-behavior: smooth;
 }
 
-.ai-message, #messages p {
+.bot-frag-ai-message, .bot-frag-messages p {
   max-width: 80%;
   margin-bottom: 15px;
   padding: 10px 15px;
@@ -70,31 +70,31 @@
   line-height: 1.4;
 }
 
-#messages p:nth-child(even) {
+.bot-frag-messages p:nth-child(even) {
   background-color: #e6e6e6;
   color: #333;
   align-self: flex-end;
 }
 
-#messages p:nth-child(odd) {
+.bot-frag-messages p:nth-child(odd) {
   background-color: #1e88e5;
   color: white;
   align-self: flex-start;
 }
 
-.ai-message {
+.bot-frag-ai-message {
   background-color: #f0f0f0;
   align-self: flex-end;
 }
 
-.input-area {
+.bot-frag-input-area {
   padding: 15px;
   background-color: #f0f2f5;
   display: flex;
   align-items: center;
 }
 
-#user-input {
+.bot-frag-user-input {
   flex: 1;
   padding: 10px 15px;
   border: none;
@@ -103,7 +103,7 @@
   outline: none;
 }
 
-#send-button {
+.bot-frag-send-button {
   background-color: #1e88e5;
   border: none;
   border-radius: 50%;
@@ -118,19 +118,19 @@
   transition: background-color 0.3s ease;
 }
 
-#send-button:disabled {
+.bot-frag-send-button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-#send-button img {
+.bot-frag-send-button img {
   width: 60%;
   height: 60%;
 }
 
-#hamburger-menu {
+.bot-frag-hamburger-menu {
   position: fixed;
-  top: 800px; /* 헤더에 맞게 조절 */
+  top: 800px;
   right: 30px;
   cursor: pointer;
   z-index: 1001;
@@ -145,7 +145,7 @@
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 }
 
-#hamburger-menu span {
+.bot-frag-hamburger-menu span {
   display: block;
   width: 25px;
   height: 3px;
@@ -154,23 +154,23 @@
   transition: 0.4s;
 }
 
-body.chatbot-open #chat-sidebar {
+body.bot-frag-open .bot-frag-sidebar {
   right: 0;
 }
 
-body.chatbot-open #hamburger-menu span:nth-child(1) {
+body.bot-frag-open .bot-frag-hamburger-menu span:nth-child(1) {
   transform: rotate(-45deg) translate(-5px, 6px);
 }
 
-body.chatbot-open #hamburger-menu span:nth-child(2) {
+body.bot-frag-open .bot-frag-hamburger-menu span:nth-child(2) {
   opacity: 0;
 }
 
-body.chatbot-open #hamburger-menu span:nth-child(3) {
+body.bot-frag-open .bot-frag-hamburger-menu span:nth-child(3) {
   transform: rotate(45deg) translate(-5px, -6px);
 }
 
-.code-block-wrapper {
+.bot-frag-code-block-wrapper {
   background-color: #f0f0f0;
   border: 1px solid #ccc;
   border-radius: 4px;
@@ -179,16 +179,16 @@ body.chatbot-open #hamburger-menu span:nth-child(3) {
   overflow-x: auto;
 }
 
-.markdown-body {
+.bot-frag-markdown-body {
   font-size: 14px;
   line-height: 1.6;
 }
 
-.markdown-body p {
+.bot-frag-markdown-body p {
   margin-bottom: 10px;
 }
 
-.markdown-body pre {
+.bot-frag-markdown-body pre {
   background-color: #f6f8fa;
   border-radius: 3px;
   font-size: 85%;

--- a/src/main/resources/static/css/fragments/chatting.css
+++ b/src/main/resources/static/css/fragments/chatting.css
@@ -1,4 +1,4 @@
-.chat-frag body, .chat-frag html {
+.chat-frag-body, .chat-frag-html {
   height: 100%;
   margin: 0;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
@@ -267,16 +267,16 @@ body.chat-open .chat-frag-hamburger span:nth-child(3) {
   width: 120px;
 }
 
-#chat-send-invite {
+#chat-frag-send-invite {
   background-color: #1e88e5;
   color: white;
 }
 
-#chat-cancel-invite {
+#chat-frag-cancel-invite {
   background-color: #f0f2f5;
   color: #333;
 }
 
-#chat-cancel-invite:hover {
+#chat-frag-cancel-invite:hover {
   background-color: #e0e0e0;
 }

--- a/src/main/resources/static/js/fragments/chatbot.js
+++ b/src/main/resources/static/js/fragments/chatbot.js
@@ -35,13 +35,6 @@ class BotFragChatbotComponent {
       if (!this.isResponding) this.sendMessage();
     });
 
-    // 화면의 다른 부분을 클릭하면 채팅창을 닫음
-    document.addEventListener('click', (event) => {
-      if (!this.chatSidebar.contains(event.target) && !this.hamburgerMenu.contains(event.target)) {
-        document.body.classList.remove('bot-frag-open');
-      }
-    });
-
     // 이전 대화 내용을 세션 스토리지에서 불러옴
     this.loadConversation();
     this.scrollToBottom(); // 대화 불러온 후 스크롤을 맨 아래로 이동

--- a/src/main/resources/static/js/fragments/chatbot.js
+++ b/src/main/resources/static/js/fragments/chatbot.js
@@ -1,20 +1,11 @@
-/**
- * @author JSW
- *
- * 사용자가 입력한 메시지를 서버에 전송하고, 서버로부터 실시간으로 응답을 받아 화면에 표시하는 기능을 수행합니다. (SSE 연결)
- * 메시지 전송 시 HTML 특수 문자를 이스케이프 처리하고, 서버 응답을 마크다운 형식으로 렌더링하는 기능도 합니다.
- */
-
 class BotFragChatbotComponent {
-  // 생성자 함수: backendUrl을 받아서 멤버 변수로 저장하고, init 메서드를 호출하여 초기화 작업을 수행
   constructor(backendUrl) {
     this.backendUrl = backendUrl;
-    this.currentEventSource = null; // 현재 SSE 연결을 관리하는 변수
-    this.isResponding = false; // AI가 응답 중인지 여부를 추적
-    this.init(); // 초기화 함수 호출
+    this.currentEventSource = null;
+    this.isResponding = false;
+    this.init();
   }
 
-  // 초기화 함수: DOM 요소를 찾고, 이벤트 리스너를 설정하는 역할
   init() {
     this.hamburgerMenu = document.getElementById('bot-frag-hamburger-menu');
     this.chatSidebar = document.getElementById('bot-frag-sidebar');
@@ -22,42 +13,46 @@ class BotFragChatbotComponent {
     this.userInput = document.getElementById('bot-frag-user-input');
     this.sendButton = document.getElementById('bot-frag-send-button');
 
-    // 햄버거 메뉴를 클릭할 때 챗봇을 토글
-    this.hamburgerMenu.addEventListener('click', () => this.toggleChatbot());
+    if (this.hamburgerMenu) {
+      this.hamburgerMenu.addEventListener('click', () => this.toggleChatbot());
+    } else {
+      console.error("Hamburger menu element not found for bot component");
+    }
 
-    // Enter 키를 누르면서 AI가 응답 중이 아닐 때 메시지 전송
-    this.userInput.addEventListener('keypress', (event) => {
-      if (event.key === 'Enter' && !this.isResponding) this.sendMessage();
-    });
+    if (this.userInput) {
+      this.userInput.addEventListener('keypress', (event) => {
+        if (event.key === 'Enter' && !this.isResponding) this.sendMessage();
+      });
+    }
 
-    // 전송 버튼 클릭 시 메시지 전송 (AI가 응답 중이 아닐 때만)
-    this.sendButton.addEventListener('click', () => {
-      if (!this.isResponding) this.sendMessage();
-    });
+    if (this.sendButton) {
+      this.sendButton.addEventListener('click', () => {
+        if (!this.isResponding) this.sendMessage();
+      });
+    }
 
-    // 이전 대화 내용을 세션 스토리지에서 불러옴
     this.loadConversation();
-    this.scrollToBottom(); // 대화 불러온 후 스크롤을 맨 아래로 이동
+    this.scrollToBottom();
 
-    // 창 크기 변경 시 스크롤을 맨 아래로 조정
     window.addEventListener('resize', () => this.scrollToBottom());
   }
 
-  // 채팅창을 열거나 닫는 기능
   toggleChatbot() {
     document.body.classList.toggle('bot-frag-open');
-    // 챗봇이 열렸을 때 스크롤을 맨 아래로 이동
+    if (this.chatSidebar) {
+      this.chatSidebar.style.right = document.body.classList.contains('bot-frag-open') ? '0' : '-500px';
+    }
     if (document.body.classList.contains('bot-frag-open')) {
-      setTimeout(() => this.scrollToBottom(), 300); // 애니메이션 완료 후 스크롤
+      setTimeout(() => this.scrollToBottom(), 300);
     }
   }
 
-  // 스크롤을 메시지 영역의 맨 아래로 이동하는 함수
   scrollToBottom() {
-    this.messages.scrollTop = this.messages.scrollHeight;
+    if (this.messages) {
+      this.messages.scrollTop = this.messages.scrollHeight;
+    }
   }
 
-  // HTML 특수문자를 이스케이프 처리하여 XSS 방지
   escapeHtml(unsafe) {
     return unsafe
     .replace(/&/g, "&amp;")
@@ -67,136 +62,143 @@ class BotFragChatbotComponent {
     .replace(/'/g, "&#039;");
   }
 
-  // 현재 대화를 세션 스토리지에 저장
   saveConversation() {
     sessionStorage.setItem('bot-frag-conversation', this.messages.innerHTML);
   }
 
-  // 세션 스토리지에서 대화를 불러와 화면에 렌더링
   loadConversation() {
     const savedConversation = sessionStorage.getItem('bot-frag-conversation');
-    if (savedConversation) {
+    if (savedConversation && this.messages) {
       this.messages.innerHTML = savedConversation;
-      // 코드 블록에 대한 하이라이팅 적용
       this.messages.querySelectorAll('pre code').forEach((block) => {
         hljs.highlightBlock(block);
       });
-      this.scrollToBottom(); // 대화 로드 후 스크롤을 맨 아래로 이동
+      this.scrollToBottom();
     }
   }
 
-  // 대화 내용을 지우고 세션 스토리지에서 삭제
   clearConversation() {
     sessionStorage.removeItem('bot-frag-conversation');
-    this.messages.innerHTML = '';
+    if (this.messages) {
+      this.messages.innerHTML = '';
+    }
   }
 
-  // 사용자 입력을 비활성화하는 함수
   disableUserInput() {
-    this.sendButton.disabled = true; // 전송 버튼 비활성화
-    this.isResponding = true; // AI 응답 중 상태로 변경
+    if (this.sendButton) {
+      this.sendButton.disabled = true;
+    }
+    this.isResponding = true;
   }
 
-  // 사용자 입력을 활성화하는 함수
   enableUserInput() {
-    this.sendButton.disabled = false; // 전송 버튼 활성화
-    this.isResponding = false; // AI 응답 완료 상태로 변경
+    if (this.sendButton) {
+      this.sendButton.disabled = false;
+    }
+    this.isResponding = false;
   }
 
-  // 사용자가 입력한 메시지를 서버에 전송하고 응답을 처리하는 함수
   sendMessage() {
-    const message = this.userInput.value.trim(); // 입력한 메시지에서 공백 제거
-    if (!message) return; // 입력이 비어있으면 종료
-    this.userInput.value = ''; // 입력 필드 초기화
+    const message = this.userInput.value.trim();
+    if (!message) return;
+    this.userInput.value = '';
 
-    // 기존 SSE 연결이 있으면 종료
     if (this.currentEventSource) {
       this.currentEventSource.close();
     }
 
-    // 사용자의 메시지를 화면에 추가 (HTML 이스케이프 처리 후)
     const escapedMessage = this.escapeHtml(message);
     this.messages.insertAdjacentHTML('beforeend', `<p><strong>You:</strong> ${escapedMessage}</p>`);
-    this.scrollToBottom(); // 메시지 추가 후 스크롤
+    this.scrollToBottom();
 
-    // AI 응답을 받을 요소 생성
     const aiResponseElement = document.createElement('div');
     aiResponseElement.className = 'bot-frag-ai-message';
     aiResponseElement.innerHTML = '<strong>AI:</strong> <span class="bot-frag-loading">Thinking...</span>';
     this.messages.appendChild(aiResponseElement);
-    this.scrollToBottom(); // AI 응답 요소 추가 후 스크롤
+    this.scrollToBottom();
 
-    this.disableUserInput(); // 사용자의 입력을 비활성화
+    this.disableUserInput();
 
-    // SSE를 통해 서버로 메시지 전송
     this.currentEventSource = new EventSource(`${this.backendUrl}/ai/api/chat/stream?content=${encodeURIComponent(message)}`);
-    let lastResponse = ''; // 마지막으로 받은 응답을 저장할 변수
+    let lastResponse = '';
 
-    // 서버로부터 메시지를 실시간으로 받음
     this.currentEventSource.onmessage = (event) => {
       try {
-        const jsonResponse = JSON.parse(event.data); // 서버로부터 받은 데이터를 JSON으로 파싱
+        const jsonResponse = JSON.parse(event.data);
         if (jsonResponse && jsonResponse.data && jsonResponse.data.content) {
-          lastResponse = jsonResponse.data.content; // 마지막 응답 내용 저장
-          let parsedMarkdown = marked.parse(lastResponse); // 응답을 마크다운 형식으로 파싱
-          // 코드 블록을 감싸는 추가 스타일 적용
+          lastResponse = jsonResponse.data.content;
+          let parsedMarkdown = marked.parse(lastResponse);
           parsedMarkdown = parsedMarkdown.replace(/<pre><code([^>]*)>/g, '<div class="bot-frag-code-block-wrapper"><pre><code$1>');
           parsedMarkdown = parsedMarkdown.replace(/<\/code><\/pre>/g, '</code></pre></div>');
           aiResponseElement.innerHTML = `<strong>AI:</strong> <div class="bot-frag-markdown-body">${parsedMarkdown}</div>`;
-          // 코드 블록 하이라이팅
           aiResponseElement.querySelectorAll('pre code').forEach((block) => {
             hljs.highlightBlock(block);
           });
-          this.saveConversation(); // 대화 저장
-          this.scrollToBottom(); // 메시지 추가 후 스크롤
+          this.saveConversation();
+          this.scrollToBottom();
         }
       } catch (error) {
         console.error('Error processing response:', error, 'Raw data:', event.data);
       }
     };
 
-    // SSE 오류 발생 시 처리
     this.currentEventSource.onerror = (event) => {
       console.error('EventSource failed:', event);
       this.currentEventSource.close();
-      this.enableUserInput(); // 사용자 입력 활성화
+      this.enableUserInput();
       if (lastResponse) {
-        // 마지막 응답이 있을 경우 마크다운 파싱 및 렌더링
         let parsedMarkdown = marked.parse(lastResponse);
         parsedMarkdown = parsedMarkdown.replace(/<pre><code([^>]*)>/g, '<div class="bot-frag-code-block-wrapper"><pre><code$1>');
         parsedMarkdown = parsedMarkdown.replace(/<\/code><\/pre>/g, '</code></pre></div>');
         aiResponseElement.innerHTML = `<strong>AI:</strong> <div class="bot-frag-markdown-body">${parsedMarkdown}</div>`;
       } else {
-        aiResponseElement.querySelector('.bot-frag-loading').textContent = 'Error occurred. Please try again.'; // 오류 메시지 표시
+        aiResponseElement.querySelector('.bot-frag-loading').textContent = 'Error occurred. Please try again.';
       }
-      this.saveConversation(); // 대화 저장
-      this.scrollToBottom(); // 스크롤 이동
+      this.saveConversation();
+      this.scrollToBottom();
     };
 
-    // SSE 연결이 종료되었을 때 처리
     this.currentEventSource.onclose = () => {
-      this.enableUserInput(); // 사용자 입력 활성화
+      this.enableUserInput();
       if (lastResponse) {
-        // 마지막 응답이 있을 경우 마크다운 파싱 및 렌더링
         let parsedMarkdown = marked.parse(lastResponse);
         parsedMarkdown = parsedMarkdown.replace(/<pre><code([^>]*)>/g, '<div class="bot-frag-code-block-wrapper"><pre><code$1>');
         parsedMarkdown = parsedMarkdown.replace(/<\/code><\/pre>/g, '</code></pre></div>');
         aiResponseElement.innerHTML = `<strong>AI:</strong> <div class="bot-frag-markdown-body">${parsedMarkdown}</div>`;
       }
-      this.saveConversation(); // 대화 저장
-      this.scrollToBottom(); // 스크롤 이동
+      this.saveConversation();
+      this.scrollToBottom();
     };
   }
 }
 
-// 챗봇 컴포넌트 초기화
+// 전역 변수로 인스턴스 저장
+let botFragChatbotInstance = null;
+
 document.addEventListener('DOMContentLoaded', function() {
   const chatbotElement = document.getElementById('bot-frag-component');
-  const backendUrl = chatbotElement.dataset.backendUrl;
-  console.log("Backend URL from data attribute:", backendUrl);
-  if (backendUrl) {
-    new BotFragChatbotComponent(backendUrl);
+  if (chatbotElement) {
+    const backendUrl = chatbotElement.dataset.backendUrl;
+    if (backendUrl) {
+      botFragChatbotInstance = new BotFragChatbotComponent(backendUrl);
+    } else {
+      console.error("Backend URL is not set properly");
+    }
   } else {
-    console.error("Backend URL is not set properly");
+    console.error("Chatbot component element not found");
+  }
+
+  // 햄버거 메뉴 이벤트 리스너 추가
+  const hamburgerMenu = document.getElementById('bot-frag-hamburger-menu');
+  if (hamburgerMenu) {
+    hamburgerMenu.addEventListener('click', function() {
+      if (botFragChatbotInstance) {
+        botFragChatbotInstance.toggleChatbot();
+      } else {
+        console.error("Chatbot instance not initialized");
+      }
+    });
+  } else {
+    console.error("Hamburger menu element not found");
   }
 });

--- a/src/main/resources/static/js/fragments/chatbot.js
+++ b/src/main/resources/static/js/fragments/chatbot.js
@@ -5,7 +5,7 @@
  * 메시지 전송 시 HTML 특수 문자를 이스케이프 처리하고, 서버 응답을 마크다운 형식으로 렌더링하는 기능도 합니다.
  */
 
-class ChatbotComponent {
+class BotFragChatbotComponent {
   // 생성자 함수: backendUrl을 받아서 멤버 변수로 저장하고, init 메서드를 호출하여 초기화 작업을 수행
   constructor(backendUrl) {
     this.backendUrl = backendUrl;
@@ -16,11 +16,11 @@ class ChatbotComponent {
 
   // 초기화 함수: DOM 요소를 찾고, 이벤트 리스너를 설정하는 역할
   init() {
-    this.hamburgerMenu = document.getElementById('hamburger-menu'); // 햄버거 메뉴 버튼 요소
-    this.chatSidebar = document.getElementById('chat-sidebar'); // 채팅 사이드바 요소
-    this.messages = document.getElementById('messages'); // 메시지 출력 요소
-    this.userInput = document.getElementById('user-input'); // 사용자 입력란
-    this.sendButton = document.getElementById('send-button'); // 전송 버튼
+    this.hamburgerMenu = document.getElementById('bot-frag-hamburger-menu');
+    this.chatSidebar = document.getElementById('bot-frag-sidebar');
+    this.messages = document.getElementById('bot-frag-messages');
+    this.userInput = document.getElementById('bot-frag-user-input');
+    this.sendButton = document.getElementById('bot-frag-send-button');
 
     // 햄버거 메뉴를 클릭할 때 챗봇을 토글
     this.hamburgerMenu.addEventListener('click', () => this.toggleChatbot());
@@ -38,7 +38,7 @@ class ChatbotComponent {
     // 화면의 다른 부분을 클릭하면 채팅창을 닫음
     document.addEventListener('click', (event) => {
       if (!this.chatSidebar.contains(event.target) && !this.hamburgerMenu.contains(event.target)) {
-        document.body.classList.remove('chatbot-open');
+        document.body.classList.remove('bot-frag-open');
       }
     });
 
@@ -52,9 +52,9 @@ class ChatbotComponent {
 
   // 채팅창을 열거나 닫는 기능
   toggleChatbot() {
-    document.body.classList.toggle('chatbot-open');
+    document.body.classList.toggle('bot-frag-open');
     // 챗봇이 열렸을 때 스크롤을 맨 아래로 이동
-    if (document.body.classList.contains('chatbot-open')) {
+    if (document.body.classList.contains('bot-frag-open')) {
       setTimeout(() => this.scrollToBottom(), 300); // 애니메이션 완료 후 스크롤
     }
   }
@@ -76,12 +76,12 @@ class ChatbotComponent {
 
   // 현재 대화를 세션 스토리지에 저장
   saveConversation() {
-    sessionStorage.setItem('chatConversation', this.messages.innerHTML);
+    sessionStorage.setItem('bot-frag-conversation', this.messages.innerHTML);
   }
 
   // 세션 스토리지에서 대화를 불러와 화면에 렌더링
   loadConversation() {
-    const savedConversation = sessionStorage.getItem('chatConversation');
+    const savedConversation = sessionStorage.getItem('bot-frag-conversation');
     if (savedConversation) {
       this.messages.innerHTML = savedConversation;
       // 코드 블록에 대한 하이라이팅 적용
@@ -94,7 +94,7 @@ class ChatbotComponent {
 
   // 대화 내용을 지우고 세션 스토리지에서 삭제
   clearConversation() {
-    sessionStorage.removeItem('chatConversation');
+    sessionStorage.removeItem('bot-frag-conversation');
     this.messages.innerHTML = '';
   }
 
@@ -128,8 +128,8 @@ class ChatbotComponent {
 
     // AI 응답을 받을 요소 생성
     const aiResponseElement = document.createElement('div');
-    aiResponseElement.className = 'ai-message';
-    aiResponseElement.innerHTML = '<strong>AI:</strong> <span class="loading">Thinking...</span>';
+    aiResponseElement.className = 'bot-frag-ai-message';
+    aiResponseElement.innerHTML = '<strong>AI:</strong> <span class="bot-frag-loading">Thinking...</span>';
     this.messages.appendChild(aiResponseElement);
     this.scrollToBottom(); // AI 응답 요소 추가 후 스크롤
 
@@ -147,9 +147,9 @@ class ChatbotComponent {
           lastResponse = jsonResponse.data.content; // 마지막 응답 내용 저장
           let parsedMarkdown = marked.parse(lastResponse); // 응답을 마크다운 형식으로 파싱
           // 코드 블록을 감싸는 추가 스타일 적용
-          parsedMarkdown = parsedMarkdown.replace(/<pre><code([^>]*)>/g, '<div class="code-block-wrapper"><pre><code$1>');
+          parsedMarkdown = parsedMarkdown.replace(/<pre><code([^>]*)>/g, '<div class="bot-frag-code-block-wrapper"><pre><code$1>');
           parsedMarkdown = parsedMarkdown.replace(/<\/code><\/pre>/g, '</code></pre></div>');
-          aiResponseElement.innerHTML = `<strong>AI:</strong> <div class="markdown-body">${parsedMarkdown}</div>`;
+          aiResponseElement.innerHTML = `<strong>AI:</strong> <div class="bot-frag-markdown-body">${parsedMarkdown}</div>`;
           // 코드 블록 하이라이팅
           aiResponseElement.querySelectorAll('pre code').forEach((block) => {
             hljs.highlightBlock(block);
@@ -170,11 +170,11 @@ class ChatbotComponent {
       if (lastResponse) {
         // 마지막 응답이 있을 경우 마크다운 파싱 및 렌더링
         let parsedMarkdown = marked.parse(lastResponse);
-        parsedMarkdown = parsedMarkdown.replace(/<pre><code([^>]*)>/g, '<div class="code-block-wrapper"><pre><code$1>');
+        parsedMarkdown = parsedMarkdown.replace(/<pre><code([^>]*)>/g, '<div class="bot-frag-code-block-wrapper"><pre><code$1>');
         parsedMarkdown = parsedMarkdown.replace(/<\/code><\/pre>/g, '</code></pre></div>');
-        aiResponseElement.innerHTML = `<strong>AI:</strong> <div class="markdown-body">${parsedMarkdown}</div>`;
+        aiResponseElement.innerHTML = `<strong>AI:</strong> <div class="bot-frag-markdown-body">${parsedMarkdown}</div>`;
       } else {
-        aiResponseElement.querySelector('.loading').textContent = 'Error occurred. Please try again.'; // 오류 메시지 표시
+        aiResponseElement.querySelector('.bot-frag-loading').textContent = 'Error occurred. Please try again.'; // 오류 메시지 표시
       }
       this.saveConversation(); // 대화 저장
       this.scrollToBottom(); // 스크롤 이동
@@ -186,12 +186,24 @@ class ChatbotComponent {
       if (lastResponse) {
         // 마지막 응답이 있을 경우 마크다운 파싱 및 렌더링
         let parsedMarkdown = marked.parse(lastResponse);
-        parsedMarkdown = parsedMarkdown.replace(/<pre><code([^>]*)>/g, '<div class="code-block-wrapper"><pre><code$1>');
+        parsedMarkdown = parsedMarkdown.replace(/<pre><code([^>]*)>/g, '<div class="bot-frag-code-block-wrapper"><pre><code$1>');
         parsedMarkdown = parsedMarkdown.replace(/<\/code><\/pre>/g, '</code></pre></div>');
-        aiResponseElement.innerHTML = `<strong>AI:</strong> <div class="markdown-body">${parsedMarkdown}</div>`;
+        aiResponseElement.innerHTML = `<strong>AI:</strong> <div class="bot-frag-markdown-body">${parsedMarkdown}</div>`;
       }
       this.saveConversation(); // 대화 저장
       this.scrollToBottom(); // 스크롤 이동
     };
   }
 }
+
+// 챗봇 컴포넌트 초기화
+document.addEventListener('DOMContentLoaded', function() {
+  const chatbotElement = document.getElementById('bot-frag-component');
+  const backendUrl = chatbotElement.dataset.backendUrl;
+  console.log("Backend URL from data attribute:", backendUrl);
+  if (backendUrl) {
+    new BotFragChatbotComponent(backendUrl);
+  } else {
+    console.error("Backend URL is not set properly");
+  }
+});

--- a/src/main/resources/static/js/fragments/chatting.js
+++ b/src/main/resources/static/js/fragments/chatting.js
@@ -1,302 +1,305 @@
-let chatStompClient = null;
-let chatCurrentRoomId = null;
-let chatCurrentUserNickname = null;
-let chatCurrentView = 'room-list';
+const chatFrag = {
+  stompClient: null,
+  currentRoomId: null,
+  currentUserNickname: null,
+  currentView: 'room-list',
 
-function chatConnect() {
-  const socket = new SockJS('/algoy/chat-websocket');
-  chatStompClient = Stomp.over(socket);
-  chatStompClient.connect({}, function () {
-    chatLoadRooms();
-    chatFetchCurrentUserInfo();
-  }, function (error) {
-    console.error('STOMP error:', error);
-    setTimeout(chatConnect, 5000); // 5초 후 재연결 시도
-  });
-}
-
-function chatFetchCurrentUserInfo() {
-  fetch('/algoy/api/user/current')
-  .then(response => response.json())
-  .then(user => {
-    chatCurrentUserNickname = user.nickname;
-  })
-  .catch(error => console.error('Error fetching current user info:', error));
-}
-
-function chatLoadRooms() {
-  fetch('/algoy/api/chat/rooms')
-  .then(response => response.json())
-  .then(rooms => {
-    const roomList = document.getElementById('chat-room-list');
-    roomList.innerHTML = '';
-    rooms.forEach(room => {
-      const roomElement = document.createElement('div');
-      roomElement.classList.add('chat-frag-room-item');
-      roomElement.textContent = room.name;
-      roomElement.onclick = () => chatJoinRoom(room.roomId);
-      roomList.appendChild(roomElement);
+  connect: function() {
+    const socket = new SockJS('/algoy/chat-websocket');
+    this.stompClient = Stomp.over(socket);
+    this.stompClient.connect({}, () => {
+      this.loadRooms();
+      this.fetchCurrentUserInfo();
+    }, (error) => {
+      console.error('STOMP error:', error);
+      setTimeout(() => this.connect(), 5000);
     });
-  })
-  .catch(error => console.error('Error loading rooms:', error));
-}
+  },
 
-function chatCreateRoom() {
-  const roomName = document.getElementById('chat-room-name').value.trim();
-  const inviteUsers = document.getElementById('chat-invite-users').value.split(',').map(s => s.trim()).filter(s => s !== '');
+  fetchCurrentUserInfo: function() {
+    fetch('/algoy/api/user/current')
+    .then(response => response.json())
+    .then(user => {
+      this.currentUserNickname = user.nickname;
+    })
+    .catch(error => console.error('Error fetching current user info:', error));
+  },
 
-  if (!roomName) {
-    alert('방 이름을 입력해주세요.');
-    return;
-  }
-
-  if (inviteUsers.length === 0) {
-    alert('초대할 사용자를 최소 한 명 이상 입력해주세요.');
-    return;
-  }
-
-  if (inviteUsers.includes(chatCurrentUserNickname)) {
-    alert('자기 자신을 초대할 수 없습니다.');
-    return;
-  }
-
-  fetch('/algoy/api/chat/room', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({name: roomName, invitees: inviteUsers})
-  })
-  .then(response => {
-    if (!response.ok) {
-      return response.json().then(err => {
-        throw err;
+  loadRooms: function() {
+    fetch('/algoy/api/chat/rooms')
+    .then(response => response.json())
+    .then(rooms => {
+      const roomList = document.getElementById('chat-frag-room-list');
+      roomList.innerHTML = '';
+      rooms.forEach(room => {
+        const roomElement = document.createElement('div');
+        roomElement.classList.add('chat-frag-room-item');
+        roomElement.textContent = room.name;
+        roomElement.onclick = () => this.joinRoom(room.roomId);
+        roomList.appendChild(roomElement);
       });
+    })
+    .catch(error => console.error('Error loading rooms:', error));
+  },
+
+  createRoom: function() {
+    const roomName = document.getElementById('chat-frag-room-name').value.trim();
+    const inviteUsers = document.getElementById('chat-frag-invite-users').value.split(',').map(s => s.trim()).filter(s => s !== '');
+
+    if (!roomName) {
+      alert('방 이름을 입력해주세요.');
+      return;
     }
-    return response.json();
-  })
-  .then(room => {
-    chatJoinRoom(room.roomId);
-  })
-  .catch(error => {
-    console.error('Error creating room:', error);
-    alert('방 생성 중 오류가 발생했습니다: ' + error.message);
-  });
-}
 
-function chatJoinRoom(roomId) {
-  if (chatCurrentRoomId) {
-    chatStompClient.unsubscribe(chatCurrentRoomId);
-  }
-  fetch(`/algoy/api/chat/room/${roomId}/join`, {method: 'POST'})
-  .then(response => response.json())
-  .then(roomDto => {
-    chatCurrentRoomId = roomDto.roomId;
-    chatShowChatRoomView(roomDto.name);
-    chatLoadMessages(roomDto.roomId);
-    chatStompClient.subscribe(`/topic/room/${roomDto.roomId}`, chatOnMessageReceived, {id: chatCurrentRoomId});
-  })
-  .catch(error => console.error('Error joining room:', error));
-}
+    if (inviteUsers.length === 0) {
+      alert('초대할 사용자를 최소 한 명 이상 입력해주세요.');
+      return;
+    }
 
-function chatLeaveRoom() {
-  if (chatCurrentRoomId) {
-    fetch(`/algoy/api/chat/room/${chatCurrentRoomId}/leave`, {method: 'POST'})
+    if (inviteUsers.includes(this.currentUserNickname)) {
+      alert('자기 자신을 초대할 수 없습니다.');
+      return;
+    }
+
+    fetch('/algoy/api/chat/room', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({name: roomName, invitees: inviteUsers})
+    })
     .then(response => {
       if (!response.ok) {
-        throw new Error('Failed to leave room');
+        return response.json().then(err => { throw err; });
+      }
+      return response.json();
+    })
+    .then(room => {
+      this.joinRoom(room.roomId);
+    })
+    .catch(error => {
+      console.error('Error creating room:', error);
+      alert('방 생성 중 오류가 발생했습니다: ' + error.message);
+    });
+  },
+
+  joinRoom: function(roomId) {
+    if (this.currentRoomId) {
+      this.stompClient.unsubscribe(this.currentRoomId);
+    }
+    fetch(`/algoy/api/chat/room/${roomId}/join`, {method: 'POST'})
+    .then(response => response.json())
+    .then(roomDto => {
+      this.currentRoomId = roomDto.roomId;
+      this.showChatRoomView(roomDto.name);
+      this.loadMessages(roomDto.roomId);
+      this.stompClient.subscribe(`/topic/room/${roomDto.roomId}`, this.onMessageReceived.bind(this), {id: this.currentRoomId});
+    })
+    .catch(error => console.error('Error joining room:', error));
+  },
+
+  leaveRoom: function() {
+    if (this.currentRoomId) {
+      fetch(`/algoy/api/chat/room/${this.currentRoomId}/leave`, {method: 'POST'})
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Failed to leave room');
+        }
+        return response.json();
+      })
+      .then(data => {
+        if (data.deleted) {
+          alert('마지막으로 남은 사용자이므로 채팅방이 삭제됩니다.');
+        }
+        this.backToRoomList();
+      })
+      .catch(error => {
+        console.error('Error leaving room:', error);
+        this.backToRoomList();
+      });
+    }
+  },
+
+  loadMessages: function(roomId) {
+    fetch(`/algoy/api/chat/room/${roomId}/messages`)
+    .then(response => response.json())
+    .then(data => {
+      const chatMessages = document.getElementById('chat-frag-messages');
+      chatMessages.innerHTML = '';
+      data.content.reverse().forEach(message => {
+        this.displayMessage(message);
+      });
+    })
+    .catch(error => console.error('Error loading messages:', error));
+  },
+
+  sendMessage: function() {
+    const messageContent = document.getElementById('chat-frag-user-input').value;
+    if (messageContent && this.stompClient && this.currentRoomId) {
+      const chatMessage = {
+        roomId: this.currentRoomId,
+        content: messageContent,
+      };
+      this.stompClient.send("/algoy/chat/sendMessage", {}, JSON.stringify(chatMessage));
+      document.getElementById('chat-frag-user-input').value = '';
+    }
+  },
+
+  onMessageReceived: function(payload) {
+    const message = JSON.parse(payload.body);
+    this.displayMessage(message);
+  },
+
+  displayMessage: function(message) {
+    const messageElement = document.createElement('div');
+    messageElement.classList.add('chat-frag-message');
+
+    if (message.nickname === 'System') {
+      messageElement.classList.add('system');
+    } else if (message.nickname === this.currentUserNickname) {
+      messageElement.classList.add('sent');
+    } else {
+      messageElement.classList.add('received');
+    }
+
+    const time = new Date(message.createdAt).toLocaleString();
+    messageElement.innerHTML = `
+      <strong>${message.nickname}</strong><br>
+      ${message.content}<br>
+      <small>${time}</small>
+    `;
+
+    const messagesContainer = document.getElementById('chat-frag-messages');
+    messagesContainer.appendChild(messageElement);
+
+    const scrollContainer = document.getElementById('chat-frag-messages-container');
+    scrollContainer.scrollTop = scrollContainer.scrollHeight;
+  },
+
+  showRoomListView: function() {
+    this.hideAllViews();
+    document.getElementById('chat-frag-room-list-view').classList.remove('chat-frag-hidden');
+    this.currentView = 'room-list';
+  },
+
+  showCreateRoomView: function() {
+    this.hideAllViews();
+    document.getElementById('chat-frag-create-room-view').classList.remove('chat-frag-hidden');
+    this.currentView = 'create-room';
+  },
+
+  showChatRoomView: function(roomName) {
+    this.hideAllViews();
+    document.getElementById('chat-frag-room-view').classList.remove('chat-frag-hidden');
+    document.getElementById('chat-frag-room-name-header').textContent = roomName;
+    this.currentView = 'chat-room';
+  },
+
+  showInviteModal: function() {
+    document.getElementById('chat-frag-invite-modal').classList.remove('chat-frag-hidden');
+  },
+
+  hideInviteModal: function() {
+    document.getElementById('chat-frag-invite-modal').classList.add('chat-frag-hidden');
+    document.getElementById('chat-frag-invite-nickname').value = '';
+  },
+
+  hideAllViews: function() {
+    ['chat-frag-room-list-view', 'chat-frag-create-room-view', 'chat-frag-room-view'].forEach(id => {
+      document.getElementById(id).classList.add('chat-frag-hidden');
+    });
+    this.hideInviteModal();
+  },
+
+  inviteUser: function() {
+    const inviteeNickname = document.getElementById('chat-frag-invite-nickname').value.trim();
+    if (!inviteeNickname) {
+      alert('Please enter a nickname to invite.');
+      return;
+    }
+
+    fetch(`/algoy/api/chat/room/${this.currentRoomId}/invite-by-nickname`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nickname: inviteeNickname })
+    })
+    .then(response => {
+      if (!response.ok) {
+        return response.json().then(err => { throw err; });
       }
       return response.json();
     })
     .then(data => {
-      if (data.deleted) {
-        // 방이 삭제된 경우
-        alert('마지막으로 남은 사용자이므로 채팅방이 삭제됩니다.');
-      }
-      chatBackToRoomList();
+      alert(data.message || '초대에 성공하였습니다.');
+      this.hideInviteModal();
     })
     .catch(error => {
-      console.error('Error leaving room:', error);
-      // 에러가 발생해도 일단 방 목록으로 돌아갑니다.
-      chatBackToRoomList();
+      console.error('Error inviting user:', error);
+      alert('Failed to invite user: ' + (error.error || 'Unknown error'));
     });
-  }
-}
+  },
 
-function chatLoadMessages(roomId) {
-  fetch(`/algoy/api/chat/room/${roomId}/messages`)
-  .then(response => response.json())
-  .then(data => {
-    const chatMessages = document.getElementById('chat-messages');
-    chatMessages.innerHTML = '';
-    // 메시지를 역순으로 표시
-    data.content.reverse().forEach(message => {
-      chatDisplayMessage(message);
+  goBack: function() {
+    if (this.currentView === 'chat-room') {
+      this.backToRoomList();
+    } else if (this.currentView === 'create-room') {
+      this.showRoomListView();
+    }
+  },
+
+  backToRoomList: function() {
+    if (this.currentRoomId) {
+      this.stompClient.unsubscribe(this.currentRoomId);
+    }
+    this.showRoomListView();
+    this.currentRoomId = null;
+    this.loadRooms();
+  },
+
+  toggleChat: function() {
+    document.body.classList.toggle('chat-open');
+    const sidebar = document.getElementById('chat-frag-sidebar');
+    if (sidebar) {
+      sidebar.style.right = document.body.classList.contains('chat-open') ? '0' : '-500px';
+    }
+  },
+
+  initialize: function() {
+    const hamburgerMenu = document.getElementById('chat-frag-hamburger-menu');
+    if (hamburgerMenu) {
+      hamburgerMenu.addEventListener('click', this.toggleChat.bind(this));
+    } else {
+      console.error("Hamburger menu element not found for chat component");
+    }
+
+    document.getElementById('chat-frag-create-room-btn').addEventListener('click', this.showCreateRoomView.bind(this));
+    document.getElementById('chat-frag-create-room-submit').addEventListener('click', this.createRoom.bind(this));
+    document.getElementById('chat-frag-invite-user-btn').addEventListener('click', this.showInviteModal.bind(this));
+    document.getElementById('chat-frag-send-button').addEventListener('click', this.sendMessage.bind(this));
+    document.getElementById('chat-frag-send-invite').addEventListener('click', this.inviteUser.bind(this));
+    document.getElementById('chat-frag-cancel-invite').addEventListener('click', this.hideInviteModal.bind(this));
+    document.querySelectorAll('.chat-frag-back-btn').forEach(btn => {
+      btn.addEventListener('click', this.goBack.bind(this));
     });
-  })
-  .catch(error => console.error('Error loading messages:', error));
-}
+    document.getElementById('chat-frag-leave-room-btn').addEventListener('click', this.leaveRoom.bind(this));
 
-function chatSendMessage() {
-  const messageContent = document.getElementById('chat-user-input').value;
-  if (messageContent && chatStompClient && chatCurrentRoomId) {
-    const chatMessage = {
-      roomId: chatCurrentRoomId,
-      content: messageContent,
-    };
-    chatStompClient.send("/algoy/chat/sendMessage", {}, JSON.stringify(chatMessage));
-    document.getElementById('chat-user-input').value = '';
+    document.getElementById('chat-frag-user-input').addEventListener('keypress', (e) => {
+      if (e.key === 'Enter') {
+        this.sendMessage();
+      }
+    });
+
+    window.addEventListener('click', (event) => {
+      let modal = document.getElementById('chat-frag-invite-modal');
+      if (event.target === modal) {
+        this.hideInviteModal();
+      }
+    });
+
+    this.connect();
+    this.loadRooms();
+    this.hideInviteModal();
   }
-}
+};
 
-function chatOnMessageReceived(payload) {
-  const message = JSON.parse(payload.body);
-  chatDisplayMessage(message);
-}
-
-function chatDisplayMessage(message) {
-  const messageElement = document.createElement('div');
-  messageElement.classList.add('chat-frag-message');
-
-  if (message.nickname === 'System') {
-    messageElement.classList.add('system');
-  } else if (message.nickname === chatCurrentUserNickname) {
-    messageElement.classList.add('sent');
-  } else {
-    messageElement.classList.add('received');
-  }
-
-  const time = new Date(message.createdAt).toLocaleString();
-  messageElement.innerHTML = `
-        <strong>${message.nickname}</strong><br>
-        ${message.content}<br>
-        <small>${time}</small>
-    `;
-
-  const messagesContainer = document.getElementById('chat-messages');
-  messagesContainer.appendChild(messageElement);
-
-  // 스크롤을 최신 메시지로 이동
-  const scrollContainer = document.getElementById('chat-messages-container');
-  scrollContainer.scrollTop = scrollContainer.scrollHeight;
-}
-
-function chatShowRoomListView() {
-  chatHideAllViews();
-  document.getElementById('chat-room-list-view').classList.remove('chat-frag-hidden');
-  chatCurrentView = 'room-list';
-}
-
-function chatShowCreateRoomView() {
-  chatHideAllViews();
-  document.getElementById('chat-create-room-view').classList.remove('chat-frag-hidden');
-  chatCurrentView = 'create-room';
-}
-
-function chatShowChatRoomView(roomName) {
-  chatHideAllViews();
-  document.getElementById('chat-room-view').classList.remove('chat-frag-hidden');
-  document.getElementById('chat-room-name-header').textContent = roomName;
-  chatCurrentView = 'chat-room';
-}
-
-function chatShowInviteModal() {
-  document.getElementById('chat-invite-modal').classList.remove('chat-frag-hidden');
-}
-
-function chatHideInviteModal() {
-  document.getElementById('chat-invite-modal').classList.add('chat-frag-hidden');
-  document.getElementById('chat-invite-nickname').value = '';
-}
-
-function chatHideAllViews() {
-  ['chat-room-list-view', 'chat-create-room-view', 'chat-room-view'].forEach(id => {
-    document.getElementById(id).classList.add('chat-frag-hidden');
-  });
-  chatHideInviteModal();
-}
-
-function chatInviteUser() {
-  const inviteeNickname = document.getElementById('chat-invite-nickname').value.trim();
-  if (!inviteeNickname) {
-    alert('Please enter a nickname to invite.');
-    return;
-  }
-
-  fetch(`/algoy/api/chat/room/${chatCurrentRoomId}/invite-by-nickname`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ nickname: inviteeNickname })
-  })
-  .then(response => {
-    if (!response.ok) {
-      return response.json().then(err => { throw err; });
-    }
-    return response.json();
-  })
-  .then(data => {
-    alert(data.message || '초대에 성공하였습니다.');
-    chatHideInviteModal();
-  })
-  .catch(error => {
-    console.error('Error inviting user:', error);
-    alert('Failed to invite user: ' + (error.error || 'Unknown error'));
-  });
-}
-
-function chatGoBack() {
-  if (chatCurrentView === 'chat-room') {
-    chatBackToRoomList();
-  } else if (chatCurrentView === 'create-room') {
-    chatShowRoomListView();
-  }
-}
-
-function chatBackToRoomList() {
-  if (chatCurrentRoomId) {
-    chatStompClient.unsubscribe(chatCurrentRoomId);
-  }
-  chatShowRoomListView();
-  chatCurrentRoomId = null;
-  chatLoadRooms();
-}
-
-function chatToggleChat() {
-  document.body.classList.toggle('chat-open');
-}
-
-function chatInitialize() {
-  // 햄버거 메뉴 토글 기능 추가
-  document.getElementById('chat-hamburger-menu').addEventListener('click', chatToggleChat);
-
-  document.getElementById('chat-create-room-btn').addEventListener('click', chatShowCreateRoomView);
-  document.getElementById('chat-create-room-submit').addEventListener('click', chatCreateRoom);
-  document.getElementById('chat-invite-user-btn').addEventListener('click', chatShowInviteModal);
-  document.getElementById('chat-send-button').addEventListener('click', chatSendMessage);
-  document.getElementById('chat-send-invite').addEventListener('click', chatInviteUser);
-  document.getElementById('chat-cancel-invite').addEventListener('click', chatHideInviteModal);
-  document.querySelectorAll('.chat-frag-back-btn').forEach(btn => {
-    btn.addEventListener('click', chatGoBack);
-  });
-  document.getElementById('chat-leave-room-btn').addEventListener('click', chatLeaveRoom);
-
-  document.getElementById('chat-user-input').addEventListener('keypress', function (e) {
-    if (e.key === 'Enter') {
-      chatSendMessage();
-    }
-  });
-
-  // 모달 외부 클릭 시 닫기
-  window.addEventListener('click', function (event) {
-    let modal = document.getElementById('chat-invite-modal');
-    if (event.target === modal) {
-      chatHideInviteModal();
-    }
-  });
-
-  // 초기 연결 및 방 목록 로드
-  chatConnect();
-  chatLoadRooms();
-  chatHideInviteModal(); // 초기에 모달이 표시되지 않도록 함
-}
-
-// DOM이 로드된 후 초기화 함수 실행
-document.addEventListener('DOMContentLoaded', chatInitialize);
+document.addEventListener('DOMContentLoaded', function() {
+  chatFrag.initialize();
+});

--- a/src/main/resources/templates/fragments/chatbot.html
+++ b/src/main/resources/templates/fragments/chatbot.html
@@ -44,7 +44,7 @@
       var backendUrl = chatbotElement.dataset.backendUrl;
       console.log("Backend URL from data attribute:", backendUrl);
       if (backendUrl) {
-        const chatbot = new ChatbotComponent(backendUrl);
+        new BotFragChatbotComponent(backendUrl);
       } else {
         console.error("Backend URL is not set properly");
       }

--- a/src/main/resources/templates/fragments/chatbot.html
+++ b/src/main/resources/templates/fragments/chatbot.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
 <head>
   <meta charset="UTF-8">
   <title>Chatbot Fragment</title>
@@ -7,25 +7,25 @@
 <body>
 <!-- 챗봇 컴포넌트 프래그먼트 -->
 <div th:fragment="chatbot(backendUrl)">
-  <div id="chatbot-component" th:data-backend-url="${backendUrl}">
-    <div id="hamburger-menu">
+  <div id="bot-frag-component" class="bot-frag-component" th:data-backend-url="${backendUrl}">
+    <div id="bot-frag-hamburger-menu" class="bot-frag-hamburger-menu">
       <span></span>
       <span></span>
       <span></span>
     </div>
 
-    <div id="chat-sidebar">
-      <div id="chat-container">
-        <div class="chat-header">
-          <div class="avatar">
+    <div id="bot-frag-sidebar" class="bot-frag-sidebar">
+      <div id="bot-frag-container" class="bot-frag-container">
+        <div class="bot-frag-header">
+          <div class="bot-frag-avatar">
             <img src="/img/bot_icon.png" alt="AI Avatar">
           </div>
           <h1>Alan AI</h1>
         </div>
-        <div id="messages"></div>
-        <div class="input-area">
-          <input type="text" id="user-input" placeholder="Type your message...">
-          <button id="send-button">
+        <div id="bot-frag-messages" class="bot-frag-messages"></div>
+        <div class="bot-frag-input-area">
+          <input type="text" id="bot-frag-user-input" class="bot-frag-user-input" placeholder="Type your message...">
+          <button id="bot-frag-send-button" class="bot-frag-send-button">
             <img src="/img/send_icon.png" alt="Send">
           </button>
         </div>
@@ -40,7 +40,7 @@
   <script th:src="@{/js/fragments/chatbot.js}"></script>
   <script th:inline="javascript">
     document.addEventListener('DOMContentLoaded', function() {
-      var chatbotElement = document.getElementById('chatbot-component');
+      var chatbotElement = document.getElementById('bot-frag-component');
       var backendUrl = chatbotElement.dataset.backendUrl;
       console.log("Backend URL from data attribute:", backendUrl);
       if (backendUrl) {

--- a/src/main/resources/templates/fragments/chatting.html
+++ b/src/main/resources/templates/fragments/chatting.html
@@ -7,68 +7,68 @@
 <body>
 <!-- 채팅 컴포넌트 프래그먼트 -->
 <div th:fragment="chat">
-  <div id="chat-component" class="chat-frag">
-    <div id="chat-hamburger-menu" class="chat-frag-hamburger">
+  <div id="chat-frag-component" class="chat-frag">
+    <div id="chat-frag-hamburger-menu" class="chat-frag-hamburger">
       <span></span>
       <span></span>
       <span></span>
     </div>
 
-    <div id="chat-sidebar" class="chat-frag-sidebar">
-      <div id="chat-container" class="chat-frag-container">
+    <div id="chat-frag-sidebar" class="chat-frag-sidebar">
+      <div id="chat-frag-container" class="chat-frag-container">
         <!-- 채팅방 목록 화면 -->
-        <div id="chat-room-list-view" class="chat-frag-view">
+        <div id="chat-frag-room-list-view" class="chat-frag-view">
           <div class="chat-frag-header">
             <h1>Chat Rooms</h1>
-            <button id="chat-create-room-btn" class="chat-frag-btn">+</button>
+            <button id="chat-frag-create-room-btn" class="chat-frag-btn">+</button>
           </div>
-          <div id="chat-room-list" class="chat-frag-room-list"></div>
+          <div id="chat-frag-room-list" class="chat-frag-room-list"></div>
         </div>
 
         <!-- 채팅방 화면 -->
-        <div id="chat-room-view" class="chat-frag-view chat-frag-hidden">
+        <div id="chat-frag-room-view" class="chat-frag-view chat-frag-hidden">
           <div class="chat-frag-header">
             <button class="chat-frag-back-btn">&lt;</button>
-            <h1 id="chat-room-name-header">Room Name</h1>
+            <h1 id="chat-frag-room-name-header">Room Name</h1>
             <div class="chat-frag-header-buttons">
-              <button id="chat-leave-room-btn" class="chat-frag-btn">Leave</button>
-              <button id="chat-invite-user-btn" class="chat-frag-btn">Invite</button>
+              <button id="chat-frag-leave-room-btn" class="chat-frag-btn">Leave</button>
+              <button id="chat-frag-invite-user-btn" class="chat-frag-btn">Invite</button>
             </div>
           </div>
-          <div id="chat-messages-container" class="chat-frag-messages-container">
-            <div id="chat-messages" class="chat-frag-messages"></div>
+          <div id="chat-frag-messages-container" class="chat-frag-messages-container">
+            <div id="chat-frag-messages" class="chat-frag-messages"></div>
           </div>
           <div class="chat-frag-input-area">
-            <input type="text" id="chat-user-input" class="chat-frag-input" placeholder="Type your message...">
-            <button id="chat-send-button" class="chat-frag-send-btn">
+            <input type="text" id="chat-frag-user-input" class="chat-frag-input" placeholder="Type your message...">
+            <button id="chat-frag-send-button" class="chat-frag-send-btn">
               <img src="/img/send_icon.png" alt="Send">
             </button>
           </div>
         </div>
 
         <!-- 채팅방 생성 화면 -->
-        <div id="chat-create-room-view" class="chat-frag-view chat-frag-hidden">
+        <div id="chat-frag-create-room-view" class="chat-frag-view chat-frag-hidden">
           <div class="chat-frag-header">
             <button class="chat-frag-back-btn">&lt;</button>
             <h1>Create Room</h1>
           </div>
           <div class="chat-frag-content">
-            <input type="text" id="chat-room-name" class="chat-frag-input" placeholder="Room Name">
-            <input type="text" id="chat-invite-users" class="chat-frag-input" placeholder="Invite Users (comma-separated nicknames)">
-            <button id="chat-create-room-submit" class="chat-frag-btn">Create</button>
+            <input type="text" id="chat-frag-room-name" class="chat-frag-input" placeholder="Room Name">
+            <input type="text" id="chat-frag-invite-users" class="chat-frag-input" placeholder="Invite Users (comma-separated nicknames)">
+            <button id="chat-frag-create-room-submit" class="chat-frag-btn">Create</button>
           </div>
         </div>
       </div>
     </div>
 
     <!-- 초대 모달 -->
-    <div id="chat-invite-modal" class="chat-frag-modal chat-frag-hidden">
+    <div id="chat-frag-invite-modal" class="chat-frag-modal chat-frag-hidden">
       <div class="chat-frag-modal-content">
         <h2>Invite User</h2>
-        <input type="text" id="chat-invite-nickname" class="chat-frag-input" placeholder="Enter nickname to invite">
+        <input type="text" id="chat-frag-invite-nickname" class="chat-frag-input" placeholder="Enter nickname to invite">
         <div class="chat-frag-modal-buttons">
-          <button id="chat-send-invite" class="chat-frag-btn">Send Invite</button>
-          <button id="chat-cancel-invite" class="chat-frag-btn">Cancel</button>
+          <button id="chat-frag-send-invite" class="chat-frag-btn">Send Invite</button>
+          <button id="chat-frag-cancel-invite" class="chat-frag-btn">Cancel</button>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/temp/chatbot-demo.html
+++ b/src/main/resources/templates/temp/chatbot-demo.html
@@ -42,9 +42,6 @@
   </section>
 </main>
 
-<!-- 여기에 채팅 프래그먼트 삽입 -->
-<div th:replace="~{fragments/chatting :: chat}"></div>
-
 <!-- 챗봇 컴포넌트 포함 -->
 <div th:replace="~{fragments/chatbot :: chatbot(backendUrl=${backendUrl})}"></div>
 

--- a/src/main/resources/templates/temp/chatbot-demo.html
+++ b/src/main/resources/templates/temp/chatbot-demo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -41,6 +41,9 @@
     <p>Click on the chat icon in the bottom right corner to start a conversation with our AI assistant.</p>
   </section>
 </main>
+
+<!-- 여기에 채팅 프래그먼트 삽입 -->
+<div th:replace="~{fragments/chatting :: chat}"></div>
 
 <!-- 챗봇 컴포넌트 포함 -->
 <div th:replace="~{fragments/chatbot :: chatbot(backendUrl=${backendUrl})}"></div>


### PR DESCRIPTION
## 요약
- 채팅 기능과 챗봇 기능 같은 페이지에서 쓸 수 있도록 조정

## 관련 이슈
- Closed #161 

## 변경 사항
- 챗봇 css, js 접두사에 bot-frag를 설정하여 충돌 방지
- 챗봇의 다른 곳을 클릭해도 화면이 닫히지 않게 수정

## 기타
- 중간에 햄버거 메뉴가 작동하지 않는 오류가 있었으나 이벤트 리스너가 빠진 것을 발견하고 수정해서 해결하였습니다.