### PR TITLE
Bug : SCP가 1시간 이상 걸리는 이슈

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -88,12 +88,21 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
 
-      - name: SCP to EC2
+#      - name: SCP to EC2
+#        env:
+#          EC2_USER: ${{ secrets.EC2_USER }}
+#          EC2_HOST: ${{ secrets.EC2_HOST }}
+#        run: |
+#          scp -i ~/.ssh/id_rsa build/libs/*.jar $EC2_USER@$EC2_HOST:/home/ubuntu
+
+      - name: SFTP to EC2
         env:
-          EC2_USER: ${{ secrets.EC2_USER }}
-          EC2_HOST: ${{ secrets.EC2_HOST }}
+            EC2_USER: ${{ secrets.EC2_USER }}
+            EC2_HOST: ${{ secrets.EC2_HOST }}
         run: |
-          scp -i ~/.ssh/id_rsa build/libs/*.jar $EC2_USER@$EC2_HOST:/home/ubuntu
+            sftp -i ~/.ssh/id_rsa $EC2_USER@$EC2_HOST <<EOF
+            put build/libs/*.jar /home/ubuntu
+            EOF
 
       - name: Set execute permission on jar
         env:


### PR DESCRIPTION
## 요약
- 로컬에서는 4초만에 전송되는데 github Actions에서는 기본 10분이상 1시간까지 소요됨

## 관련 이슈
- related to #196 

## 변경 사항
- gradle.yml 파일에서 scp -> sftp로 변경

## 기타
- 이슈의 원인을 찾아야 합니다
- ec2 사양을 올린다고 해도 해결되지 않을 것 같습니다
