### PR TITLE
Bug: 채팅 관련 버그 수정

### DIFF
--- a/src/main/resources/static/css/fragments/chatbot.css
+++ b/src/main/resources/static/css/fragments/chatbot.css
@@ -2,6 +2,16 @@
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
+.bot-frag-component .bot-frag-header {
+  background-color: #1e88e5;
+}
+
+.bot-frag-component .bot-frag-header h1 {
+  color: white;
+  margin: 0;
+  font-size: 18px;
+}
+
 .bot-frag-sidebar {
   position: fixed;
   right: -500px;

--- a/src/main/resources/static/css/fragments/chatting.css
+++ b/src/main/resources/static/css/fragments/chatting.css
@@ -5,6 +5,16 @@
   background-color: #f0f2f5;
 }
 
+.chat-frag .chat-frag-header {
+  background-color: #1e88e5;
+}
+
+.chat-frag .chat-frag-header h1 {
+  color: white;
+  margin: 0;
+  font-size: 18px;
+}
+
 .chat-frag {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }

--- a/src/main/resources/static/js/fragments/chatting.js
+++ b/src/main/resources/static/js/fragments/chatting.js
@@ -171,7 +171,7 @@ const chatFrag = {
     .then(data => {
       const chatMessages = document.getElementById('chat-frag-messages');
       chatMessages.innerHTML = '';
-      data.content.forEach(message => {
+      data.content.reverse().forEach(message => {
         this.displayMessage(message);
       });
     })


### PR DESCRIPTION
## 요약
- 채팅이 아래로 쌓이지 않고 역순으로 출력되는 문제 해결
- 프래그먼트가 일부 페이지에서 헤더 제목이 흰 글씨가 아닌 검은 글씨로 적용되는 문제

## 관련 이슈
- Closed #212 

## 변경 사항
- js에서 메시지 load하는 부분 reverse() 추가
- css에서 프래그먼트 헤더의 우선 순위 강화
